### PR TITLE
feat(i18n): comprehensive i18n audit improvements

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run unit tests
         run: pnpm test
 
+      - name: Validate i18n translations
+        run: pnpm vitest run tests/i18n/
+
   build:
     name: Build on ${{ matrix.os }}
     needs: quality

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run unit tests
         run: pnpm test
 
+      - name: Validate i18n translations
+        run: pnpm vitest run tests/i18n/
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Run unit tests
         run: pnpm test
 
+      - name: Validate i18n translations
+        run: pnpm vitest run tests/i18n/
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Run unit tests
         run: pnpm test
 
+      - name: Validate i18n translations
+        run: pnpm vitest run tests/i18n/
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 

--- a/scripts/extract-translations.mjs
+++ b/scripts/extract-translations.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Translation extraction & validation script for TMS integration.
+ *
+ * Usage:
+ *   node scripts/extract-translations.mjs [--format flat|nested] [--locale en]
+ *
+ * Outputs a single JSON file per locale suitable for import into
+ * Crowdin, Lokalise, Phrase, or similar TMS platforms.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+const MESSAGES_DIR = join(process.cwd(), 'src/i18n/messages');
+const OUTPUT_DIR = join(process.cwd(), 'translations-export');
+const NAMESPACES = [
+  'common',
+  'auth',
+  'profile',
+  'search',
+  'watch',
+  'live',
+  'party',
+];
+
+const args = process.argv.slice(2);
+const formatIdx = args.indexOf('--format');
+const outputFormat = formatIdx !== -1 ? args[formatIdx + 1] : 'flat';
+const localeIdx = args.indexOf('--locale');
+const targetLocale = localeIdx !== -1 ? args[localeIdx + 1] : null;
+
+function flattenKeys(obj, prefix = '') {
+  const result = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'object' && value !== null) {
+      Object.assign(result, flattenKeys(value, path));
+    } else {
+      result[path] = value;
+    }
+  }
+  return result;
+}
+
+function extractLocale(locale) {
+  const merged = {};
+  for (const ns of NAMESPACES) {
+    const filePath = join(MESSAGES_DIR, locale, `${ns}.json`);
+    const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+    if (outputFormat === 'flat') {
+      const flat = flattenKeys(data, ns);
+      Object.assign(merged, flat);
+    } else {
+      merged[ns] = data;
+    }
+  }
+  return merged;
+}
+
+// Ensure output directory exists
+if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
+
+const locales = targetLocale
+  ? [targetLocale]
+  : readdirSync(MESSAGES_DIR).filter((d) =>
+      existsSync(join(MESSAGES_DIR, d, 'common.json')),
+    );
+
+let totalKeys = 0;
+for (const locale of locales) {
+  const data = extractLocale(locale);
+  const keyCount =
+    outputFormat === 'flat' ? Object.keys(data).length : '(nested)';
+  const outPath = join(OUTPUT_DIR, `${locale}.json`);
+  writeFileSync(outPath, `${JSON.stringify(data, null, 2)}\n`);
+  console.log(`  ✓ ${locale}.json — ${keyCount} keys`);
+  if (typeof keyCount === 'number') totalKeys = keyCount;
+}
+
+console.log(`\nExported ${locales.length} locale(s) to ${OUTPUT_DIR}/`);
+if (totalKeys) console.log(`Keys per locale: ${totalKeys}`);
+console.log(`Format: ${outputFormat}`);

--- a/src/app/(protected)/(main)/continue-watching/page.tsx
+++ b/src/app/(protected)/(main)/continue-watching/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import ContinueWatchingClient from './ContinueWatchingClient';
 
-export const metadata: Metadata = {
-  title: 'Continue Watching | Watch Rudra',
-  description:
-    'Pick up where you left off with your recently watched movies and TV shows.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('common.metadata');
+  return {
+    title: t('continueWatchingTitle'),
+    description: t('continueWatchingDescription'),
+  };
+}
 
 export default async function ContinueWatchingPage() {
   return <ContinueWatchingClient />;

--- a/src/app/(protected)/(main)/downloads/page.tsx
+++ b/src/app/(protected)/(main)/downloads/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import DownloadsClient from './DownloadsClient';
 
-export const metadata: Metadata = {
-  title: 'Downloads | Watch Rudra',
-  description:
-    'Access your downloaded movies and TV shows for offline viewing.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('common.metadata');
+  return {
+    title: t('downloadsTitle'),
+    description: t('downloadsDescription'),
+  };
+}
 
 export default async function DownloadsPage() {
   return <DownloadsClient />;

--- a/src/app/(protected)/(main)/home/page.tsx
+++ b/src/app/(protected)/(main)/home/page.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import { HomeClient } from '@/features/search/components/HomeClient';
 
-export const metadata: Metadata = {
-  title: 'Home | Watch Rudra',
-  description: 'Search for movies and TV shows to start watching together.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('common.metadata');
+  return {
+    title: t('homeTitle'),
+    description: t('homeDescription'),
+  };
+}
 
 export default async function HomePage() {
   return <HomeClient />;

--- a/src/app/(protected)/(main)/live/LiveClient.tsx
+++ b/src/app/(protected)/(main)/live/LiveClient.tsx
@@ -8,7 +8,7 @@ import {
   Globe2,
   Radio,
 } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { LiveMatchSkeleton } from '@/components/ui/skeletons';
@@ -26,6 +26,7 @@ function LiveContent() {
   const [isServerMenuOpen, setIsServerMenuOpen] = useState(false);
   const [isSportMenuOpen, setIsSportMenuOpen] = useState(false);
   const t = useTranslations('live');
+  const format = useFormatter();
 
   const SERVERS = [
     { id: 'server1' as const, label: t('server1'), desc: t('server1Desc') },
@@ -65,7 +66,7 @@ function LiveContent() {
 
   const upcomingByDate = activeMatches.reduce(
     (acc, match) => {
-      const date = new Date(match.startTime).toLocaleDateString([], {
+      const date = format.dateTime(new Date(match.startTime), {
         weekday: 'short',
         month: 'short',
         day: 'numeric',
@@ -335,7 +336,7 @@ function LiveContent() {
                     <div className="space-y-8">
                       {Object.entries(upcomingByDate).map(([date, matches]) => {
                         const isToday =
-                          new Date().toLocaleDateString([], {
+                          format.dateTime(new Date(), {
                             weekday: 'short',
                             month: 'short',
                             day: 'numeric',

--- a/src/app/(protected)/(main)/live/page.tsx
+++ b/src/app/(protected)/(main)/live/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import LiveClient from './LiveClient';
 
-export const metadata: Metadata = {
-  title: 'Live Matches | Watch Rudra',
-  description:
-    'Watch live sports matches and channels with your friends in real-time.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('common.metadata');
+  return {
+    title: t('liveTitle'),
+    description: t('liveDescription'),
+  };
+}
 
 export default async function LivePage() {
   return <LiveClient />;

--- a/src/app/(protected)/(main)/profile/page.tsx
+++ b/src/app/(protected)/(main)/profile/page.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import ProfileClient from './ProfileClient';
 
-export const metadata: Metadata = {
-  title: 'Profile | Watch Rudra',
-  description: 'Manage your profile and viewing history.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('common.metadata');
+  return {
+    title: t('profileTitle'),
+    description: t('profileDescription'),
+  };
+}
 
 export default async function ProfilePage() {
   return <ProfileClient />;

--- a/src/app/(protected)/(main)/search/page.tsx
+++ b/src/app/(protected)/(main)/search/page.tsx
@@ -1,13 +1,17 @@
 import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import { Suspense } from 'react';
 import { searchContent } from '@/features/search/api';
 import { SearchClient } from '@/features/search/components/SearchClient';
 import type { SearchResult } from '@/features/search/types';
 
-export const metadata: Metadata = {
-  title: 'Search | Watch Rudra',
-  description: 'Search for movies, TV shows, and anime.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('common.metadata');
+  return {
+    title: t('searchTitle'),
+    description: t('searchDescription'),
+  };
+}
 
 function SearchFallback() {
   return (

--- a/src/app/(protected)/(main)/watchlist/page.tsx
+++ b/src/app/(protected)/(main)/watchlist/page.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import WatchlistClient from './WatchlistClient';
 
-export const metadata: Metadata = {
-  title: 'My Watchlist | Watch Rudra',
-  description: 'Keep track of movies and TV shows you want to watch later.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('common.metadata');
+  return {
+    title: t('watchlistTitle'),
+    description: t('watchlistDescription'),
+  };
+}
 
 export default async function WatchlistPage() {
   return <WatchlistClient />;

--- a/src/app/(protected)/live/[id]/page.tsx
+++ b/src/app/(protected)/live/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { ArrowLeft, Calendar, Loader2, Trophy } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -25,6 +25,7 @@ export default function LiveMatchPlayerPage() {
   const titleFromRoute = searchParams.get('title')?.trim() ?? '';
   const { match, isLoading, error } = useLiveMatch(matchId);
   const t = useTranslations('live');
+  const format = useFormatter();
 
   const [sessionUrl, setSessionUrl] = useState<string | null>(null);
   const [sessionLoading, setSessionLoading] = useState(false);
@@ -392,7 +393,7 @@ export default function LiveMatchPlayerPage() {
     </div>
   );
 
-  const startLabel = new Date(activeMatch.startTime).toLocaleString([], {
+  const startLabel = format.dateTime(new Date(activeMatch.startTime), {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/src/app/(public)/login/LoginClient.tsx
+++ b/src/app/(public)/login/LoginClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { LanguageSwitcher } from '@/components/layout/language-switcher';
 import { GlobalLoading } from '@/components/ui/global-loading';
 import { ForgotPasswordForm } from '@/features/auth/components/forgot-password-form';
 import { LoginForm } from '@/features/auth/components/login-form';
@@ -74,6 +75,7 @@ export default function LoginClient() {
     <div
       className={`bg-background text-foreground h-screen h-[100dvh] flex flex-col font-body overflow-hidden transition-[transform,opacity] duration-700 ease-out origin-top motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:zoom-in-[0.99] motion-reduce:animate-none ${isTransitioning ? 'scale-[0.98] -translate-y-4 opacity-0 pointer-events-none' : 'scale-100 translate-y-0 opacity-100'}`}
     >
+      <LanguageSwitcher className="absolute top-4 right-4 z-50" />
       <main className="flex-grow flex flex-col items-center p-1 md:p-2 justify-center overflow-hidden w-full max-w-[1400px] mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-2 lg:gap-4 w-full max-w-5xl items-stretch pb-2 md:pb-0 shrink-0">
           {/* Features Bento Box - Identical to Signup for Parity */}

--- a/src/app/(public)/signup/SignupClient.tsx
+++ b/src/app/(public)/signup/SignupClient.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
+import { LanguageSwitcher } from '@/components/layout/language-switcher';
 import { Button } from '@/components/ui/button';
 import { GlobalLoading } from '@/components/ui/global-loading';
 import { SignupForm } from '@/features/auth/components/signup-form';
@@ -43,6 +44,7 @@ export default function SignupClient() {
     <div
       className={`bg-background text-foreground h-screen h-[100dvh] flex flex-col font-body overflow-hidden transition-[transform,opacity] duration-700 ease-out origin-top motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:zoom-in-[0.99] motion-reduce:animate-none ${isTransitioning ? 'scale-[0.98] -translate-y-4 opacity-0 pointer-events-none' : 'scale-100 translate-y-0 opacity-100'}`}
     >
+      <LanguageSwitcher className="absolute top-4 right-4 z-50" />
       <main className="flex-grow flex flex-col items-center p-1 md:p-2 justify-center overflow-hidden w-full max-w-[1400px] mx-auto">
         {isInviteValid === false ? (
           <div className="flex flex-col items-center justify-center p-8 bg-background border-4 border-border  max-w-md w-full motion-safe:animate-in motion-safe:zoom-in motion-safe:duration-300 motion-reduce:animate-none">

--- a/src/app/(public)/user/[id]/page.tsx
+++ b/src/app/(public)/user/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
 import { getPublicProfile } from '@/features/profile/api';
 import { PublicProfileView } from '@/features/profile/components/public-profile-view';
 
@@ -12,30 +13,30 @@ interface Props {
  */
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
+  const t = await getTranslations('common.metadata');
   const result = await getPublicProfile(id).catch(() => null);
 
   if (!result?.profile) {
-    return {
-      title: 'User Not Found | Rudra Watch',
-    };
+    return { title: t('userNotFoundTitle') };
   }
 
   const profile = result.profile;
   const displayName = profile.name || profile.username || 'User';
+  const username = profile.username || displayName;
 
   return {
-    title: `${displayName} (@${profile.username}) | Rudra Watch`,
-    description: `View ${displayName}'s watch activity and profile on Rudra Watch.`,
+    title: t('userProfileTitle', { name: displayName, username }),
+    description: t('userProfileDescription', { name: displayName }),
     openGraph: {
-      title: `${displayName} on Rudra Watch`,
-      description: `Watch history and activity profile for ${displayName}.`,
+      title: t('userProfileOgTitle', { name: displayName }),
+      description: t('userProfileDescription', { name: displayName }),
       images: profile.profilePhoto ? [profile.profilePhoto] : [],
       type: 'profile',
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${displayName} | Rudra Watch`,
-      description: `Watch history and activity profile for ${displayName}.`,
+      title: t('userProfileTitle', { name: displayName, username }),
+      description: t('userProfileDescription', { name: displayName }),
       images: profile.profilePhoto ? [profile.profilePhoto] : [],
     },
   };

--- a/src/app/(public)/whats-new/release-list.tsx
+++ b/src/app/(public)/whats-new/release-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
@@ -23,6 +23,7 @@ const INITIAL_COUNT = 3;
 export function ReleaseList({ releases }: { releases: Release[] }) {
   const [visibleCount, setVisibleCount] = useState(INITIAL_COUNT);
   const t = useTranslations('common.whatsNew');
+  const format = useFormatter();
   const visible = releases.slice(0, visibleCount);
   const hasMore = visibleCount < releases.length;
 
@@ -59,14 +60,11 @@ export function ReleaseList({ releases }: { releases: Release[] }) {
                 </span>
                 <span>•</span>
                 <time dateTime={release.published_at}>
-                  {new Date(release.published_at).toLocaleDateString(
-                    undefined,
-                    {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    },
-                  )}
+                  {format.dateTime(new Date(release.published_at), {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
                 </time>
               </div>
             </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -425,6 +425,179 @@
     @apply bg-background text-foreground;
   }
 
+  /* ── RTL support ─────────────────────────────────────────── */
+  /* When dir="rtl" is set on <html>, flip directional layout */
+  [dir="rtl"] {
+    direction: rtl;
+    text-align: right;
+  }
+
+  [dir="rtl"] .flex-row {
+    flex-direction: row-reverse;
+  }
+
+  [dir="rtl"] .space-x-1 > :not(:last-child),
+  [dir="rtl"] .space-x-2 > :not(:last-child),
+  [dir="rtl"] .space-x-3 > :not(:last-child),
+  [dir="rtl"] .space-x-4 > :not(:last-child),
+  [dir="rtl"] .space-x-6 > :not(:last-child) {
+    margin-right: 0;
+    margin-left: var(--tw-space-x-reverse);
+  }
+
+  /* Mirror directional margins and paddings */
+  [dir="rtl"] .ml-auto {
+    margin-left: unset;
+    margin-right: auto;
+  }
+  [dir="rtl"] .mr-auto {
+    margin-right: unset;
+    margin-left: auto;
+  }
+  [dir="rtl"] .ml-1 {
+    margin-left: unset;
+    margin-right: 0.25rem;
+  }
+  [dir="rtl"] .ml-2 {
+    margin-left: unset;
+    margin-right: 0.5rem;
+  }
+  [dir="rtl"] .ml-3 {
+    margin-left: unset;
+    margin-right: 0.75rem;
+  }
+  [dir="rtl"] .ml-4 {
+    margin-left: unset;
+    margin-right: 1rem;
+  }
+  [dir="rtl"] .mr-1 {
+    margin-right: unset;
+    margin-left: 0.25rem;
+  }
+  [dir="rtl"] .mr-2 {
+    margin-right: unset;
+    margin-left: 0.5rem;
+  }
+  [dir="rtl"] .mr-3 {
+    margin-right: unset;
+    margin-left: 0.75rem;
+  }
+  [dir="rtl"] .mr-4 {
+    margin-right: unset;
+    margin-left: 1rem;
+  }
+  [dir="rtl"] .pl-2 {
+    padding-left: unset;
+    padding-right: 0.5rem;
+  }
+  [dir="rtl"] .pl-3 {
+    padding-left: unset;
+    padding-right: 0.75rem;
+  }
+  [dir="rtl"] .pl-4 {
+    padding-left: unset;
+    padding-right: 1rem;
+  }
+  [dir="rtl"] .pl-6 {
+    padding-left: unset;
+    padding-right: 1.5rem;
+  }
+  [dir="rtl"] .pr-2 {
+    padding-right: unset;
+    padding-left: 0.5rem;
+  }
+  [dir="rtl"] .pr-3 {
+    padding-right: unset;
+    padding-left: 0.75rem;
+  }
+  [dir="rtl"] .pr-4 {
+    padding-right: unset;
+    padding-left: 1rem;
+  }
+  [dir="rtl"] .pr-6 {
+    padding-right: unset;
+    padding-left: 1.5rem;
+  }
+
+  /* Mirror text alignment */
+  [dir="rtl"] .text-left {
+    text-align: right;
+  }
+  [dir="rtl"] .text-right {
+    text-align: left;
+  }
+
+  /* Mirror absolute/fixed positioning */
+  [dir="rtl"] .left-0 {
+    left: unset;
+    right: 0;
+  }
+  [dir="rtl"] .right-0 {
+    right: unset;
+    left: 0;
+  }
+  [dir="rtl"] .left-2 {
+    left: unset;
+    right: 0.5rem;
+  }
+  [dir="rtl"] .right-2 {
+    right: unset;
+    left: 0.5rem;
+  }
+  [dir="rtl"] .left-4 {
+    left: unset;
+    right: 1rem;
+  }
+  [dir="rtl"] .right-4 {
+    right: unset;
+    left: 1rem;
+  }
+
+  /* Mirror translate-x transforms */
+  [dir="rtl"] .translate-x-full {
+    --tw-translate-x: -100%;
+  }
+  [dir="rtl"] .-translate-x-full {
+    --tw-translate-x: 100%;
+  }
+
+  /* Mirror rounded corners */
+  [dir="rtl"] .rounded-l-md {
+    border-radius: 0 calc(var(--radius) - 2px) calc(var(--radius) - 2px) 0;
+  }
+  [dir="rtl"] .rounded-r-md {
+    border-radius: calc(var(--radius) - 2px) 0 0 calc(var(--radius) - 2px);
+  }
+  [dir="rtl"] .rounded-l-lg {
+    border-radius: 0 var(--radius) var(--radius) 0;
+  }
+  [dir="rtl"] .rounded-r-lg {
+    border-radius: var(--radius) 0 0 var(--radius);
+  }
+
+  /* Mirror border sides */
+  [dir="rtl"] .border-l {
+    border-left: 0;
+    border-right: 1px solid;
+  }
+  [dir="rtl"] .border-r {
+    border-right: 0;
+    border-left: 1px solid;
+  }
+
+  /* Ensure gap-based layouts (flex gap, grid gap) work without mirroring */
+  /* gap is direction-agnostic, so no override needed */
+
+  /* Electron title bar padding flips */
+  [dir="rtl"] .pl-20 {
+    padding-left: unset;
+    padding-right: 5rem;
+  }
+  [dir="rtl"] .pr-32 {
+    padding-right: unset;
+    padding-left: 8rem;
+  }
+
   /* Hide scrollbar globally but maintain functionality */
   html,
   body,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,13 +47,13 @@ export const viewport: Viewport = {
   viewportFit: 'cover',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" dir="ltr" suppressHydrationWarning>
       <head>
         {/* Blocking script to set dark class before React hydrates — prevents FOUC */}
         <script

--- a/src/components/layout/language-switcher.tsx
+++ b/src/components/layout/language-switcher.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { Check, Globe } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import { useCallback, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { COOKIE_NAME, locales } from '@/i18n/config';
+import { cn } from '@/lib/utils';
+
+const LOCALE_META: Record<string, { native: string; english: string }> = {
+  en: { native: 'English', english: 'English' },
+  hi: { native: 'हिन्दी', english: 'Hindi' },
+  es: { native: 'Español', english: 'Spanish' },
+  fr: { native: 'Français', english: 'French' },
+  ja: { native: '日本語', english: 'Japanese' },
+  ko: { native: '한국어', english: 'Korean' },
+  de: { native: 'Deutsch', english: 'German' },
+  pt: { native: 'Português', english: 'Portuguese' },
+  ar: { native: 'العربية', english: 'Arabic' },
+  ru: { native: 'Русский', english: 'Russian' },
+  zh: { native: '中文', english: 'Chinese' },
+  it: { native: 'Italiano', english: 'Italian' },
+  tr: { native: 'Türkçe', english: 'Turkish' },
+  th: { native: 'ไทย', english: 'Thai' },
+};
+
+function setCookie(name: string, value: string) {
+  // biome-ignore lint/suspicious/noDocumentCookie: required for SSR locale detection
+  document.cookie = `${name}=${value};path=/;max-age=31536000;samesite=lax`;
+}
+
+export function LanguageSwitcher({
+  className,
+  trigger,
+}: {
+  className?: string;
+  trigger?: React.ReactNode;
+}) {
+  const locale = useLocale();
+  const router = useRouter();
+  const t = useTranslations('common.language');
+  const tCancel = useTranslations('profile.preferences');
+  const [open, setOpen] = useState(false);
+
+  const switchLocale = useCallback(
+    (newLocale: string) => {
+      setCookie(COOKIE_NAME, newLocale);
+      localStorage.setItem('preferred-locale', newLocale);
+      setOpen(false);
+      router.refresh();
+    },
+    [router],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <button
+            type="button"
+            className={cn(
+              'flex items-center gap-2 px-3 py-2 text-xs font-headline font-bold uppercase tracking-widest transition-colors rounded-md border border-border bg-background/80 backdrop-blur-sm hover:bg-muted cursor-pointer',
+              className,
+            )}
+            aria-label={t('title')}
+          >
+            <Globe className="w-4 h-4" />
+            {LOCALE_META[locale]?.native || locale}
+          </button>
+        )}
+      </DialogTrigger>
+
+      <DialogContent
+        className="!fixed !inset-0 !left-0 !top-0 !translate-x-0 !translate-y-0 z-[10100] !max-w-none w-screen h-screen m-0 p-0 border-none bg-white/80 dark:bg-black/60 backdrop-blur-2xl shadow-none !flex flex-col items-center [-webkit-app-region:no-drag] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 duration-500 overflow-hidden"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">{t('title')}</DialogTitle>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="absolute top-8 right-8 z-50 text-foreground/50 hover:text-foreground font-headline font-black uppercase tracking-[0.2em] text-sm transition-colors"
+        >
+          {tCancel('cancel')}
+        </button>
+
+        <div className="flex flex-col items-center w-full max-w-md px-6 h-full pt-16">
+          <h2 className="text-3xl md:text-5xl font-black font-headline uppercase tracking-tighter text-foreground shrink-0 mb-6">
+            {t('title')}
+          </h2>
+          <div className="flex flex-col w-full gap-1 overflow-y-auto flex-1 pb-16">
+            {locales.map((l) => (
+              <button
+                key={l}
+                type="button"
+                onClick={() => switchLocale(l)}
+                className={cn(
+                  'w-full px-6 py-4 flex items-center justify-between text-left transition-all duration-200',
+                  locale === l
+                    ? 'text-foreground font-black [text-shadow:0_0_12px_rgba(255,255,255,0.5)]'
+                    : 'text-foreground/30 hover:text-foreground/60',
+                )}
+              >
+                <div className="flex flex-col">
+                  <span className="text-lg font-headline font-bold tracking-wide">
+                    {LOCALE_META[l]?.native}
+                  </span>
+                  <span className="text-xs opacity-60 uppercase tracking-widest font-bold">
+                    {LOCALE_META[l]?.english}
+                  </span>
+                </div>
+                {locale === l && <Check className="w-5 h-5 stroke-[3px]" />}
+              </button>
+            ))}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/livestream/components/LiveMatchModal.tsx
+++ b/src/features/livestream/components/LiveMatchModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Loader2, Play, Users, X } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { useEffect, useRef } from 'react';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { cn } from '@/lib/utils';
@@ -109,6 +109,7 @@ function LiveMatchModalContent({
 }: Omit<LiveMatchModalProps, 'isOpen'> & { isMobile: boolean }) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const t = useTranslations('live');
+  const format = useFormatter();
 
   // Escape key to close + auto-focus on open
   useEffect(() => {
@@ -157,11 +158,11 @@ function LiveMatchModalContent({
   };
 
   const startTime = new Date(match.startTime);
-  const formattedTime = startTime.toLocaleTimeString([], {
+  const formattedTime = format.dateTime(startTime, {
     hour: '2-digit',
     minute: '2-digit',
   });
-  const formattedDate = startTime.toLocaleDateString([], {
+  const formattedDate = format.dateTime(startTime, {
     weekday: 'short',
     month: 'short',
     day: 'numeric',

--- a/src/features/livestream/hooks/use-live-match-card.ts
+++ b/src/features/livestream/hooks/use-live-match-card.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { createPartyRoom } from '@/features/watch-party/room/services/watch-party.api';
@@ -14,6 +14,7 @@ export function useLiveMatchCard(match: LiveMatch) {
   const { user } = useAuth();
   const t = useTranslations('live');
   const tp = useTranslations('party.toasts');
+  const format = useFormatter();
 
   const isLive = match.status === 'MatchIng';
   const isEnded = match.status === 'MatchEnded';
@@ -29,11 +30,11 @@ export function useLiveMatchCard(match: LiveMatch) {
       match.playType === 'hls');
 
   const startTime = new Date(match.startTime);
-  const formattedTime = startTime.toLocaleTimeString([], {
+  const formattedTime = format.dateTime(startTime, {
     hour: '2-digit',
     minute: '2-digit',
   });
-  const formattedDate = startTime.toLocaleDateString([], {
+  const formattedDate = format.dateTime(startTime, {
     month: 'short',
     day: 'numeric',
   });

--- a/src/features/profile/components/app-preferences.tsx
+++ b/src/features/profile/components/app-preferences.tsx
@@ -11,9 +11,9 @@ import {
   Sun,
   Zap,
 } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { LanguageSwitcher } from '@/components/layout/language-switcher';
 import {
   Dialog,
   DialogClose,
@@ -21,27 +21,9 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { COOKIE_NAME, locales } from '@/i18n/config';
 import { checkIsDesktop, desktopBridge } from '@/lib/electron-bridge';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/providers/theme-provider';
-
-const LOCALE_META: Record<string, { native: string; english: string }> = {
-  en: { native: 'English', english: 'English' },
-  hi: { native: 'हिन्दी', english: 'Hindi' },
-  es: { native: 'Español', english: 'Spanish' },
-  fr: { native: 'Français', english: 'French' },
-  ja: { native: '日本語', english: 'Japanese' },
-  ko: { native: '한국어', english: 'Korean' },
-  de: { native: 'Deutsch', english: 'German' },
-  pt: { native: 'Português', english: 'Portuguese' },
-  ar: { native: 'العربية', english: 'Arabic' },
-  ru: { native: 'Русский', english: 'Russian' },
-  zh: { native: '中文', english: 'Chinese' },
-  it: { native: 'Italiano', english: 'Italian' },
-  tr: { native: 'Türkçe', english: 'Turkish' },
-  th: { native: 'ไทย', english: 'Thai' },
-};
 
 const THEME_META = [
   { id: 'light' as const, label: 'Light', Icon: Sun },
@@ -49,16 +31,10 @@ const THEME_META = [
   { id: 'system' as const, label: 'System', Icon: Monitor },
 ];
 
-function setCookie(name: string, value: string) {
-  // biome-ignore lint/suspicious/noDocumentCookie: required for SSR locale detection
-  document.cookie = `${name}=${value};path=/;max-age=31536000;samesite=lax`;
-}
-
 export function AppPreferences() {
   const t = useTranslations('profile');
   const { theme, setTheme } = useTheme();
   const locale = useLocale();
-  const router = useRouter();
 
   const [runOnBoot, setRunOnBoot] = useState(false);
   const [concurrentDownloads, setConcurrentDownloads] = useState<number>(3);
@@ -66,7 +42,6 @@ export function AppPreferences() {
   const [downloadSpeedLimit, setDownloadSpeedLimit] = useState<number>(0);
   const [customSpeed, setCustomSpeed] = useState('');
   const [isDesktop, setIsDesktop] = useState(false);
-  const [langOpen, setLangOpen] = useState(false);
   const [themeOpen, setThemeOpen] = useState(false);
 
   useEffect(() => {
@@ -83,16 +58,6 @@ export function AppPreferences() {
       });
     }
   }, []);
-
-  const switchLocale = useCallback(
-    (newLocale: string) => {
-      setCookie(COOKIE_NAME, newLocale);
-      localStorage.setItem('preferred-locale', newLocale);
-      setLangOpen(false);
-      router.refresh();
-    },
-    [router],
-  );
 
   const handleToggleRunOnBoot = () => {
     const newValue = !runOnBoot;
@@ -232,66 +197,17 @@ export function AppPreferences() {
             </p>
           </div>
 
-          <Dialog open={langOpen} onOpenChange={setLangOpen}>
-            <DialogTrigger asChild>
+          <LanguageSwitcher
+            trigger={
               <button
                 type="button"
                 className="flex items-center gap-3 px-5 py-3 border rounded-lg transition-all shadow-sm cursor-pointer bg-card text-card-foreground border-border hover:border-primary/50 hover:shadow-md"
               >
                 <Globe className="w-4 h-4" />
-                {LOCALE_META[locale]?.native || locale}
+                {locale}
               </button>
-            </DialogTrigger>
-
-            <DialogContent
-              className="!fixed !inset-0 !left-0 !top-0 !translate-x-0 !translate-y-0 z-[10100] !max-w-none w-screen h-screen m-0 p-0 border-none bg-white/80 dark:bg-black/60 backdrop-blur-2xl shadow-none !flex flex-col items-center [-webkit-app-region:no-drag] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 duration-500 overflow-hidden"
-              showCloseButton={false}
-            >
-              <DialogTitle className="sr-only">
-                {t('preferences.selectLanguage')}
-              </DialogTitle>
-              <button
-                type="button"
-                onClick={() => setLangOpen(false)}
-                className="absolute top-8 right-8 z-50 text-foreground/50 hover:text-foreground font-headline font-black uppercase tracking-[0.2em] text-sm transition-colors"
-              >
-                {t('preferences.cancel')}
-              </button>
-
-              <div className="flex flex-col items-center w-full max-w-md px-6 h-full pt-16">
-                <h2 className="text-3xl md:text-5xl font-black font-headline uppercase tracking-tighter text-foreground shrink-0 mb-6">
-                  {t('preferences.language')}
-                </h2>
-                <div className="flex flex-col w-full gap-1 overflow-y-auto flex-1 pb-16">
-                  {locales.map((l) => (
-                    <button
-                      key={l}
-                      type="button"
-                      onClick={() => switchLocale(l)}
-                      className={cn(
-                        'w-full px-6 py-4 flex items-center justify-between text-left transition-all duration-200',
-                        locale === l
-                          ? 'text-foreground font-black [text-shadow:0_0_12px_rgba(255,255,255,0.5)]'
-                          : 'text-foreground/30 hover:text-foreground/60',
-                      )}
-                    >
-                      <div className="flex flex-col">
-                        <span className="text-lg font-headline font-bold tracking-wide">
-                          {LOCALE_META[l]?.native}
-                        </span>
-                        <span className="text-xs opacity-60 uppercase tracking-widest font-bold">
-                          {LOCALE_META[l]?.english}
-                        </span>
-                      </div>
-                      {locale === l && (
-                        <Check className="w-5 h-5 stroke-[3px]" />
-                      )}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </DialogContent>
-          </Dialog>
+            }
+          />
         </div>
 
         {/* Desktop Only Settings */}

--- a/src/features/profile/components/public-profile-view.tsx
+++ b/src/features/profile/components/public-profile-view.tsx
@@ -2,7 +2,7 @@
 
 import { Calendar, Home, User } from 'lucide-react';
 import Link from 'next/link';
-import { useLocale, useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { CreatorFooter } from '@/components/ui/creator-footer';
 import type { WatchActivity } from '../types';
 import { ActivityGraph } from './activity-graph';
@@ -25,8 +25,8 @@ export function PublicProfileView({
   todayIso,
 }: PublicProfileViewProps) {
   const t = useTranslations('profile');
-  const locale = useLocale();
-  const joinDate = new Date(profile.createdAt).toLocaleDateString(locale, {
+  const format = useFormatter();
+  const joinDate = format.dateTime(new Date(profile.createdAt), {
     month: 'long',
     year: 'numeric',
   });

--- a/src/features/profile/hooks/use-profile-overview.ts
+++ b/src/features/profile/hooks/use-profile-overview.ts
@@ -1,4 +1,4 @@
-import { useLocale, useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -9,7 +9,7 @@ import type { WatchActivity } from '../types';
 export function useProfileOverview() {
   const { user, logout, updateUser } = useAuth();
   const t = useTranslations('profile.messages');
-  const locale = useLocale();
+  const format = useFormatter();
   const [activity, setActivity] = useState<WatchActivity[]>([]);
   const [loadingActivity, setLoadingActivity] = useState(true);
   const [isUploading, setIsUploading] = useState(false);
@@ -72,12 +72,12 @@ export function useProfileOverview() {
   const formattedJoinDate = useMemo(
     () =>
       userCreatedAtDate
-        ? userCreatedAtDate.toLocaleDateString(locale, {
+        ? format.dateTime(userCreatedAtDate, {
             month: 'long',
             year: 'numeric',
           })
         : t('unknown'),
-    [userCreatedAtDate, locale, t],
+    [userCreatedAtDate, format, t],
   );
 
   return {

--- a/src/features/search/components/search-results.tsx
+++ b/src/features/search/components/search-results.tsx
@@ -85,6 +85,7 @@ const SearchResultItem = React.memo(function SearchResultItem({
   index,
 }: SearchResultItemProps) {
   const { imageError, setImageError } = useSearchResultItem();
+  const t = useTranslations('search');
 
   return (
     <Card className="p-2">
@@ -93,7 +94,7 @@ const SearchResultItem = React.memo(function SearchResultItem({
         type="button"
         className="group aspect-[2/3] border-[3px] border-border overflow-hidden relative mb-4 flex-shrink-0 cursor-pointer w-full p-0 bg-background"
         onClick={() => onSelect(result)}
-        aria-label={`View details for ${result.title}`}
+        aria-label={t('results.viewDetailsFor', { title: result.title })}
       >
         {imageError ? (
           <div className="absolute inset-0 flex items-center justify-center bg-background">

--- a/src/features/watch-party/chat/components/WatchPartyChat.tsx
+++ b/src/features/watch-party/chat/components/WatchPartyChat.tsx
@@ -1,7 +1,7 @@
 import { EmojiStyle, Theme } from 'emoji-picker-react';
 import { ExternalLink, Send, Smile } from 'lucide-react';
 import dynamic from 'next/dynamic';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { memo, useMemo } from 'react';
 import { useTheme } from '@/providers/theme-provider';
 
@@ -278,6 +278,7 @@ const ChatMessageItem = memo(function ChatMessageItem({
   isMe,
   showHeader,
 }: ChatMessageItemProps) {
+  const format = useFormatter();
   // Detect if message is a single emoji
   const isSingleEmoji = useMemo(() => {
     const trimmed = message.content.trim();
@@ -328,7 +329,7 @@ const ChatMessageItem = memo(function ChatMessageItem({
             {message.userName}
           </span>
           <span className="text-[10px] text-foreground/70 font-bold font-headline uppercase tracking-widest">
-            {new Date(message.timestamp).toLocaleTimeString([], {
+            {format.dateTime(new Date(message.timestamp), {
               hour: '2-digit',
               minute: '2-digit',
             })}
@@ -396,7 +397,7 @@ const ChatMessageItem = memo(function ChatMessageItem({
             )}
           >
             {isSingleEmoji ? '' : ''}
-            {new Date(message.timestamp).toLocaleTimeString([], {
+            {format.dateTime(new Date(message.timestamp), {
               hour: '2-digit',
               minute: '2-digit',
             })}

--- a/src/features/watch-party/components/ActiveWatchParty.tsx
+++ b/src/features/watch-party/components/ActiveWatchParty.tsx
@@ -144,6 +144,7 @@ export function ActiveWatchParty({
   // Whether the current user is permitted to send chat messages
   const { user } = useAuth();
   const t = useTranslations('party');
+  const tAria = useTranslations('party.aria');
   const currentMember = room.members.find((m) => m.id === currentUserId);
   const currentUserName =
     currentMember?.name ||
@@ -171,7 +172,7 @@ export function ActiveWatchParty({
     >
       {/* Sidebar */}
       <aside
-        aria-label="Party sidebar"
+        aria-label={tAria('partySidebar')}
         aria-hidden={!showDesktopSidebar}
         className={cn(
           'relative overflow-hidden flex-shrink-0 transition-[width,opacity] duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] bg-background z-30',

--- a/src/features/watch-party/interactions/components/EmojiReactions.tsx
+++ b/src/features/watch-party/interactions/components/EmojiReactions.tsx
@@ -34,6 +34,7 @@ export function EmojiReactions({
     useEmojiReactions({ rtmSendMessage, userId, userName });
   const { theme: appTheme } = useTheme();
   const t = useTranslations('party');
+  const tAria = useTranslations('party.aria');
 
   const resolvedDark =
     appTheme === 'dark' ||
@@ -53,7 +54,7 @@ export function EmojiReactions({
             index > 2 && 'hidden md:block', // Show only 3 emojis on small screens
             index > 4 && 'hidden lg:block',
           )}
-          aria-label={`Send ${emoji} reaction`}
+          aria-label={tAria('sendReaction', { emoji })}
         >
           {emoji}
         </Button>

--- a/src/features/watch-party/media/hooks/useAgora.ts
+++ b/src/features/watch-party/media/hooks/useAgora.ts
@@ -555,7 +555,9 @@ export function useAgora({
       type?: string;
     }) => {
       if (evt.type === 'error' || (evt.code && evt.code >= 1000)) {
-        toast.error(`Media Error: ${evt.msg || 'An unknown error occurred'}`);
+        toast.error(
+          tp('mediaError', { message: evt.msg || tp('unknownMediaError') }),
+        );
       }
     };
 

--- a/src/features/watch/player/ui/compound/SubtitleOverlay.tsx
+++ b/src/features/watch/player/ui/compound/SubtitleOverlay.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { useSubtitleOverlay } from './hooks/use-subtitle-overlay';
 
 interface SubtitleOverlayProps {
@@ -35,6 +36,7 @@ export function SubtitleOverlay({
   currentTrackId,
 }: SubtitleOverlayProps) {
   const { cueText } = useSubtitleOverlay({ videoRef, currentTrackId });
+  const tAria = useTranslations('watch.aria');
 
   if (!cueText) return null;
 
@@ -42,7 +44,7 @@ export function SubtitleOverlay({
     <section
       className="absolute bottom-[12%] left-0 right-0 flex justify-center pointer-events-none z-20 px-4"
       aria-live="polite"
-      aria-label="Subtitle"
+      aria-label={tAria('subtitle')}
     >
       <div
         className="max-w-[80%] text-center leading-snug"

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,21 @@
+import type common from './i18n/messages/en/common.json';
+import type auth from './i18n/messages/en/auth.json';
+import type profile from './i18n/messages/en/profile.json';
+import type search from './i18n/messages/en/search.json';
+import type watch from './i18n/messages/en/watch.json';
+import type live from './i18n/messages/en/live.json';
+import type party from './i18n/messages/en/party.json';
+
+type Messages = {
+  common: typeof common;
+  auth: typeof auth;
+  profile: typeof profile;
+  search: typeof search;
+  watch: typeof watch;
+  live: typeof live;
+  party: typeof party;
+};
+
+declare global {
+  interface IntlMessages extends Messages {}
+}

--- a/src/i18n/messages/ar/common.json
+++ b/src/i18n/messages/ar/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "اللغة",
-    "description": "اختر لغتك المفضلة",
-    "closeMenu": "إغلاق قائمة اللغة"
+    "description": "اختر لغتك المفضلة"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "قائمة المشاهدة | Watch Rudra",
     "watchlistDescription": "تتبع الأفلام والمسلسلات التي تريد مشاهدتها لاحقاً.",
     "watchPartyTitle": "حفلة المشاهدة | Watch Rudra",
-    "watchPartyDescription": "انضم إلى أصدقائك وشاهدوا معاً في الوقت الفعلي."
+    "watchPartyDescription": "انضم إلى أصدقائك وشاهدوا معاً في الوقت الفعلي.",
+    "userNotFoundTitle": "المستخدم غير موجود | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "عرض نشاط المشاهدة والملف الشخصي لـ {name}.",
+    "userProfileOgTitle": "{name} على Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "التطبيق غير مثبت",
@@ -215,5 +218,11 @@
     "mb": "ميغابايت",
     "gb": "غيغابايت",
     "tb": "تيرابايت"
+  },
+  "fallbacks": {
+    "guest": "ضيف",
+    "member": "عضو",
+    "roomHost": "مضيف الغرفة",
+    "user": "مستخدم"
   }
 }

--- a/src/i18n/messages/ar/party.json
+++ b/src/i18n/messages/ar/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "رفض المضيف طلبك",
     "hostLeftRoom": "غادر المضيف الغرفة",
     "failedCreateRoom": "فشل في إنشاء الغرفة",
-    "hostEndedParty": "أنهى المضيف الحفلة."
+    "hostEndedParty": "أنهى المضيف الحفلة.",
+    "mediaError": "خطأ في الوسائط: {message}",
+    "unknownMediaError": "حدث خطأ غير معروف"
   },
   "desktop": {
     "coWatchingLiveStream": "مشاهدة البث المباشر معاً",
@@ -249,5 +251,9 @@
     "sketchFor": "الرسم لـ {name}",
     "soundsFor": "الأصوات لـ {name}",
     "chatFor": "الدردشة لـ {name}"
+  },
+  "aria": {
+    "partySidebar": "الشريط الجانبي للحفلة",
+    "sendReaction": "إرسال تفاعل {emoji}"
   }
 }

--- a/src/i18n/messages/ar/search.json
+++ b/src/i18n/messages/ar/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "لم يتم العثور على نتائج",
     "noResultsArchiveHint": "لم نتمكن من العثور على تطابقات في أرشيفنا. جرّب البحث عن عنوان أو كلمة مفتاحية مختلفة.",
     "editQueryAriaLabel": "تعديل استعلام البحث",
-    "searchingAriaLabel": "جارٍ البحث..."
+    "searchingAriaLabel": "جارٍ البحث...",
+    "viewDetailsFor": "عرض تفاصيل {title}"
   },
   "continueWatching": {
     "title": "متابعة المشاهدة",

--- a/src/i18n/messages/ar/watch.json
+++ b/src/i18n/messages/ar/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "بدون إنترنت",
     "vault": "الخزنة",
     "yourDownloads": "المحتوى المنزّل",
-    "downloadsCount": "{count} تنزيل(ات)",
+    "downloadsCount": "{count, plural, zero {# تنزيلات} one {تنزيل واحد} two {تنزيلان} few {# تنزيلات} many {# تنزيلًا} other {# تنزيل}}",
     "availableOffline": "متاح للمشاهدة بدون إنترنت",
     "emptyTitle": "الخزنة فارغة",
     "emptyDescription": "التنزيلات الآمنة ستظهر هنا",

--- a/src/i18n/messages/de/common.json
+++ b/src/i18n/messages/de/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "Sprache",
-    "description": "Wähle deine bevorzugte Sprache",
-    "closeMenu": "Sprachmenü schließen"
+    "description": "Wähle deine bevorzugte Sprache"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "Meine Merkliste | Watch Rudra",
     "watchlistDescription": "Behalte den Überblick über Filme und Serien, die du später sehen möchtest.",
     "watchPartyTitle": "Watch Party | Watch Rudra",
-    "watchPartyDescription": "Triff dich mit Freunden und schaut gemeinsam in Echtzeit."
+    "watchPartyDescription": "Triff dich mit Freunden und schaut gemeinsam in Echtzeit.",
+    "userNotFoundTitle": "Benutzer nicht gefunden | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "Sehen Sie sich die Aktivität und das Profil von {name} an.",
+    "userProfileOgTitle": "{name} auf Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "App nicht installiert",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "Gast",
+    "member": "Mitglied",
+    "roomHost": "Raumhost",
+    "user": "Benutzer"
   }
 }

--- a/src/i18n/messages/de/party.json
+++ b/src/i18n/messages/de/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "Gastgeber hat deine Anfrage abgelehnt",
     "hostLeftRoom": "Gastgeber hat den Raum verlassen",
     "failedCreateRoom": "Raum konnte nicht erstellt werden",
-    "hostEndedParty": "Der Gastgeber hat die Party beendet."
+    "hostEndedParty": "Der Gastgeber hat die Party beendet.",
+    "mediaError": "Medienfehler: {message}",
+    "unknownMediaError": "Ein unbekannter Fehler ist aufgetreten"
   },
   "desktop": {
     "coWatchingLiveStream": "Gemeinsam Livestream schauen",
@@ -249,5 +251,9 @@
     "sketchFor": "Zeichnen für {name}",
     "soundsFor": "Sounds für {name}",
     "chatFor": "Chat für {name}"
+  },
+  "aria": {
+    "partySidebar": "Party-Seitenleiste",
+    "sendReaction": "{emoji} Reaktion senden"
   }
 }

--- a/src/i18n/messages/de/search.json
+++ b/src/i18n/messages/de/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "Keine Ergebnisse gefunden",
     "noResultsArchiveHint": "Wir konnten keine Treffer in unseren Archiven finden. Versuche einen anderen Titel oder ein anderes Stichwort.",
     "editQueryAriaLabel": "Suchanfrage bearbeiten",
-    "searchingAriaLabel": "Suche läuft..."
+    "searchingAriaLabel": "Suche läuft...",
+    "viewDetailsFor": "Details für {title} anzeigen"
   },
   "continueWatching": {
     "title": "Weiterschauen",

--- a/src/i18n/messages/de/watch.json
+++ b/src/i18n/messages/de/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "OFFLINE",
     "vault": "TRESOR",
     "yourDownloads": "Deine heruntergeladenen Inhalte",
-    "downloadsCount": "{count} Download(s)",
+    "downloadsCount": "{count, plural, one {# Download} other {# Downloads}}",
     "availableOffline": "Verfügbar für Offline-Wiedergabe",
     "emptyTitle": "Tresor ist leer",
     "emptyDescription": "Sichere Downloads erscheinen hier",

--- a/src/i18n/messages/en/common.json
+++ b/src/i18n/messages/en/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "Language",
-    "description": "Choose your preferred language",
-    "closeMenu": "Close language menu"
+    "description": "Choose your preferred language"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "My Watchlist | Watch Rudra",
     "watchlistDescription": "Keep track of movies and TV shows you want to watch later.",
     "watchPartyTitle": "Watch Party | Watch Rudra",
-    "watchPartyDescription": "Join your friends and watch together in real-time."
+    "watchPartyDescription": "Join your friends and watch together in real-time.",
+    "userNotFoundTitle": "User Not Found | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "View {name}'s watch activity and profile on Watch Rudra.",
+    "userProfileOgTitle": "{name} on Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "App not installed",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "Guest",
+    "member": "Member",
+    "roomHost": "Room Host",
+    "user": "User"
   }
 }

--- a/src/i18n/messages/en/party.json
+++ b/src/i18n/messages/en/party.json
@@ -214,7 +214,9 @@
     "hostRejected": "Host rejected your request",
     "hostLeftRoom": "Host left the room",
     "failedCreateRoom": "Failed to create room",
-    "hostEndedParty": "The host has ended the party."
+    "hostEndedParty": "The host has ended the party.",
+    "mediaError": "Media Error: {message}",
+    "unknownMediaError": "An unknown error occurred"
   },
   "desktop": {
     "coWatchingLiveStream": "Co-Watching Live Stream",
@@ -249,5 +251,9 @@
     "sketchFor": "Sketch for {name}",
     "soundsFor": "Sounds for {name}",
     "chatFor": "Chat for {name}"
+  },
+  "aria": {
+    "partySidebar": "Party sidebar",
+    "sendReaction": "Send {emoji} reaction"
   }
 }

--- a/src/i18n/messages/en/search.json
+++ b/src/i18n/messages/en/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "No Results Found",
     "noResultsArchiveHint": "We couldn't find any matches in our archives. Try searching for a different title or keyword.",
     "editQueryAriaLabel": "Edit search query",
-    "searchingAriaLabel": "Searching..."
+    "searchingAriaLabel": "Searching...",
+    "viewDetailsFor": "View details for {title}"
   },
   "continueWatching": {
     "title": "Continue Watching",

--- a/src/i18n/messages/en/watch.json
+++ b/src/i18n/messages/en/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "OFFLINE",
     "vault": "VAULT",
     "yourDownloads": "Your Downloaded Content",
-    "downloadsCount": "{count} Download(s)",
+    "downloadsCount": "{count, plural, one {# Download} other {# Downloads}}",
     "availableOffline": "Available for offline viewing",
     "emptyTitle": "Vault is empty",
     "emptyDescription": "Secure downloads will appear here",

--- a/src/i18n/messages/es/common.json
+++ b/src/i18n/messages/es/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "Idioma",
-    "description": "Elige tu idioma preferido",
-    "closeMenu": "Cerrar menú de idioma"
+    "description": "Elige tu idioma preferido"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "Mi Lista | Watch Rudra",
     "watchlistDescription": "Lleva un registro de las películas y series que quieres ver después.",
     "watchPartyTitle": "Watch Party | Watch Rudra",
-    "watchPartyDescription": "Únete a tus amigos y vean juntos en tiempo real."
+    "watchPartyDescription": "Únete a tus amigos y vean juntos en tiempo real.",
+    "userNotFoundTitle": "Usuario no encontrado | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "Ver la actividad y perfil de {name} en Watch Rudra.",
+    "userProfileOgTitle": "{name} en Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "App no instalada",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "Invitado",
+    "member": "Miembro",
+    "roomHost": "Anfitrión",
+    "user": "Usuario"
   }
 }

--- a/src/i18n/messages/es/party.json
+++ b/src/i18n/messages/es/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "El anfitrión rechazó tu solicitud",
     "hostLeftRoom": "El anfitrión abandonó la sala",
     "failedCreateRoom": "Error al crear sala",
-    "hostEndedParty": "El anfitrión ha terminado la fiesta."
+    "hostEndedParty": "El anfitrión ha terminado la fiesta.",
+    "mediaError": "Error de medios: {message}",
+    "unknownMediaError": "Ocurrió un error desconocido"
   },
   "desktop": {
     "coWatchingLiveStream": "Viendo transmisión en vivo juntos",
@@ -249,5 +251,9 @@
     "sketchFor": "Dibujo para {name}",
     "soundsFor": "Sonidos para {name}",
     "chatFor": "Chat para {name}"
+  },
+  "aria": {
+    "partySidebar": "Barra lateral de la fiesta",
+    "sendReaction": "Enviar reacción {emoji}"
   }
 }

--- a/src/i18n/messages/es/search.json
+++ b/src/i18n/messages/es/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "No se encontraron resultados",
     "noResultsArchiveHint": "No encontramos coincidencias en nuestros archivos. Intenta buscar un título o palabra clave diferente.",
     "editQueryAriaLabel": "Editar consulta de búsqueda",
-    "searchingAriaLabel": "Buscando..."
+    "searchingAriaLabel": "Buscando...",
+    "viewDetailsFor": "Ver detalles de {title}"
   },
   "continueWatching": {
     "title": "Seguir viendo",

--- a/src/i18n/messages/es/watch.json
+++ b/src/i18n/messages/es/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "SIN CONEXIÓN",
     "vault": "BÓVEDA",
     "yourDownloads": "Tu contenido descargado",
-    "downloadsCount": "{count} descarga(s)",
+    "downloadsCount": "{count, plural, one {# Descarga} other {# Descargas}}",
     "availableOffline": "Disponible para ver sin conexión",
     "emptyTitle": "La bóveda está vacía",
     "emptyDescription": "Las descargas seguras aparecerán aquí",

--- a/src/i18n/messages/fr/common.json
+++ b/src/i18n/messages/fr/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "Langue",
-    "description": "Choisissez votre langue préférée",
-    "closeMenu": "Fermer le menu de langue"
+    "description": "Choisissez votre langue préférée"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "Ma Liste | Watch Rudra",
     "watchlistDescription": "Gardez une trace des films et séries que vous souhaitez regarder plus tard.",
     "watchPartyTitle": "Watch Party | Watch Rudra",
-    "watchPartyDescription": "Rejoignez vos amis et regardez ensemble en temps réel."
+    "watchPartyDescription": "Rejoignez vos amis et regardez ensemble en temps réel.",
+    "userNotFoundTitle": "Utilisateur introuvable | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "Voir l'activité et le profil de {name} sur Watch Rudra.",
+    "userProfileOgTitle": "{name} sur Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "App non installée",
@@ -215,5 +218,11 @@
     "mb": "Mo",
     "gb": "Go",
     "tb": "To"
+  },
+  "fallbacks": {
+    "guest": "Invité",
+    "member": "Membre",
+    "roomHost": "Hôte",
+    "user": "Utilisateur"
   }
 }

--- a/src/i18n/messages/fr/party.json
+++ b/src/i18n/messages/fr/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "L'hôte a rejeté votre demande",
     "hostLeftRoom": "L'hôte a quitté le salon",
     "failedCreateRoom": "Échec de la création du salon",
-    "hostEndedParty": "L'hôte a mis fin à la fête."
+    "hostEndedParty": "L'hôte a mis fin à la fête.",
+    "mediaError": "Erreur média : {message}",
+    "unknownMediaError": "Une erreur inconnue est survenue"
   },
   "desktop": {
     "coWatchingLiveStream": "Visionnage en direct ensemble",
@@ -249,5 +251,9 @@
     "sketchFor": "Dessin pour {name}",
     "soundsFor": "Sons pour {name}",
     "chatFor": "Chat pour {name}"
+  },
+  "aria": {
+    "partySidebar": "Barre latérale de la fête",
+    "sendReaction": "Envoyer la réaction {emoji}"
   }
 }

--- a/src/i18n/messages/fr/search.json
+++ b/src/i18n/messages/fr/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "Aucun résultat trouvé",
     "noResultsArchiveHint": "Nous n'avons trouvé aucune correspondance dans nos archives. Essayez un titre ou un mot-clé différent.",
     "editQueryAriaLabel": "Modifier la requête de recherche",
-    "searchingAriaLabel": "Recherche en cours..."
+    "searchingAriaLabel": "Recherche en cours...",
+    "viewDetailsFor": "Voir les détails de {title}"
   },
   "continueWatching": {
     "title": "Continuer à regarder",

--- a/src/i18n/messages/fr/watch.json
+++ b/src/i18n/messages/fr/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "HORS LIGNE",
     "vault": "COFFRE",
     "yourDownloads": "Votre contenu téléchargé",
-    "downloadsCount": "{count} téléchargement(s)",
+    "downloadsCount": "{count, plural, one {# Téléchargement} other {# Téléchargements}}",
     "availableOffline": "Disponible pour visionnage hors ligne",
     "emptyTitle": "Le coffre est vide",
     "emptyDescription": "Les téléchargements sécurisés apparaîtront ici",

--- a/src/i18n/messages/hi/common.json
+++ b/src/i18n/messages/hi/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "भाषा",
-    "description": "अपनी पसंदीदा भाषा चुनें",
-    "closeMenu": "भाषा मेनू बंद करें"
+    "description": "अपनी पसंदीदा भाषा चुनें"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "मेरी वॉचलिस्ट | Watch Rudra",
     "watchlistDescription": "बाद में देखने के लिए फिल्मों और टीवी शो का ट्रैक रखें।",
     "watchPartyTitle": "वॉच पार्टी | Watch Rudra",
-    "watchPartyDescription": "अपने दोस्तों के साथ जुड़ें और रियल-टाइम में एक साथ देखें।"
+    "watchPartyDescription": "अपने दोस्तों के साथ जुड़ें और रियल-टाइम में एक साथ देखें।",
+    "userNotFoundTitle": "उपयोगकर्ता नहीं मिला | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "{name} की वॉच गतिविधि और प्रोफ़ाइल देखें।",
+    "userProfileOgTitle": "{name} Watch Rudra पर"
   },
   "desktopApp": {
     "notInstalled": "ऐप इंस्टॉल नहीं है",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "अतिथि",
+    "member": "सदस्य",
+    "roomHost": "रूम होस्ट",
+    "user": "उपयोगकर्ता"
   }
 }

--- a/src/i18n/messages/hi/party.json
+++ b/src/i18n/messages/hi/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "होस्ट ने आपका अनुरोध अस्वीकार कर दिया",
     "hostLeftRoom": "होस्ट ने रूम छोड़ दिया",
     "failedCreateRoom": "रूम बनाने में विफल",
-    "hostEndedParty": "होस्ट ने पार्टी समाप्त कर दी है।"
+    "hostEndedParty": "होस्ट ने पार्टी समाप्त कर दी है।",
+    "mediaError": "मीडिया त्रुटि: {message}",
+    "unknownMediaError": "एक अज्ञात त्रुटि हुई"
   },
   "desktop": {
     "coWatchingLiveStream": "लाइव स्ट्रीम साथ देख रहे हैं",
@@ -249,5 +251,9 @@
     "sketchFor": "{name} के लिए स्केच",
     "soundsFor": "{name} के लिए ध्वनियाँ",
     "chatFor": "{name} के लिए चैट"
+  },
+  "aria": {
+    "partySidebar": "पार्टी साइडबार",
+    "sendReaction": "{emoji} रिएक्शन भेजें"
   }
 }

--- a/src/i18n/messages/hi/search.json
+++ b/src/i18n/messages/hi/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "कोई परिणाम नहीं मिला",
     "noResultsArchiveHint": "हमें संग्रह में कोई मिलान नहीं मिला। कोई अलग शीर्षक या कीवर्ड खोजें।",
     "editQueryAriaLabel": "खोज क्वेरी संपादित करें",
-    "searchingAriaLabel": "खोज रहे हैं..."
+    "searchingAriaLabel": "खोज रहे हैं...",
+    "viewDetailsFor": "{title} के विवरण देखें"
   },
   "continueWatching": {
     "title": "देखना जारी रखें",

--- a/src/i18n/messages/hi/watch.json
+++ b/src/i18n/messages/hi/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "ऑफ़लाइन",
     "vault": "वॉल्ट",
     "yourDownloads": "आपकी डाउनलोड की गई सामग्री",
-    "downloadsCount": "{count} डाउनलोड",
+    "downloadsCount": "{count, plural, one {# डाउनलोड} other {# डाउनलोड}}",
     "availableOffline": "ऑफ़लाइन देखने के लिए उपलब्ध",
     "emptyTitle": "वॉल्ट खाली है",
     "emptyDescription": "सुरक्षित डाउनलोड यहां दिखाई देंगे",

--- a/src/i18n/messages/it/common.json
+++ b/src/i18n/messages/it/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "Lingua",
-    "description": "Scegli la tua lingua preferita",
-    "closeMenu": "Chiudi menu lingua"
+    "description": "Scegli la tua lingua preferita"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "La Mia Lista | Watch Rudra",
     "watchlistDescription": "Tieni traccia dei film e delle serie TV che vuoi guardare dopo.",
     "watchPartyTitle": "Watch Party | Watch Rudra",
-    "watchPartyDescription": "Unisciti ai tuoi amici e guardate insieme in tempo reale."
+    "watchPartyDescription": "Unisciti ai tuoi amici e guardate insieme in tempo reale.",
+    "userNotFoundTitle": "Utente non trovato | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "Visualizza l'attività e il profilo di {name} su Watch Rudra.",
+    "userProfileOgTitle": "{name} su Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "App non installata",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "Ospite",
+    "member": "Membro",
+    "roomHost": "Host della stanza",
+    "user": "Utente"
   }
 }

--- a/src/i18n/messages/it/party.json
+++ b/src/i18n/messages/it/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "L'host ha rifiutato la tua richiesta",
     "hostLeftRoom": "L'host ha lasciato la stanza",
     "failedCreateRoom": "Impossibile creare la stanza",
-    "hostEndedParty": "L'host ha terminato la festa."
+    "hostEndedParty": "L'host ha terminato la festa.",
+    "mediaError": "Errore media: {message}",
+    "unknownMediaError": "Si è verificato un errore sconosciuto"
   },
   "desktop": {
     "coWatchingLiveStream": "Visione condivisa della diretta",
@@ -249,5 +251,9 @@
     "sketchFor": "Disegno per {name}",
     "soundsFor": "Suoni per {name}",
     "chatFor": "Chat per {name}"
+  },
+  "aria": {
+    "partySidebar": "Barra laterale della festa",
+    "sendReaction": "Invia reazione {emoji}"
   }
 }

--- a/src/i18n/messages/it/search.json
+++ b/src/i18n/messages/it/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "Nessun risultato trovato",
     "noResultsArchiveHint": "Non abbiamo trovato corrispondenze nei nostri archivi. Prova a cercare un titolo o una parola chiave diversa.",
     "editQueryAriaLabel": "Modifica ricerca",
-    "searchingAriaLabel": "Ricerca in corso..."
+    "searchingAriaLabel": "Ricerca in corso...",
+    "viewDetailsFor": "Visualizza dettagli di {title}"
   },
   "continueWatching": {
     "title": "Continua a guardare",

--- a/src/i18n/messages/it/watch.json
+++ b/src/i18n/messages/it/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "OFFLINE",
     "vault": "ARCHIVIO",
     "yourDownloads": "I tuoi contenuti scaricati",
-    "downloadsCount": "{count} Download",
+    "downloadsCount": "{count, plural, one {# Download} other {# Download}}",
     "availableOffline": "Disponibile per la visione offline",
     "emptyTitle": "Il vault è vuoto",
     "emptyDescription": "I download sicuri appariranno qui",

--- a/src/i18n/messages/ja/common.json
+++ b/src/i18n/messages/ja/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "言語",
-    "description": "お好みの言語を選択してください",
-    "closeMenu": "言語メニューを閉じる"
+    "description": "お好みの言語を選択してください"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "マイウォッチリスト | Watch Rudra",
     "watchlistDescription": "後で見たい映画やテレビ番組を管理。",
     "watchPartyTitle": "ウォッチパーティー | Watch Rudra",
-    "watchPartyDescription": "友達と一緒にリアルタイムで視聴しましょう。"
+    "watchPartyDescription": "友達と一緒にリアルタイムで視聴しましょう。",
+    "userNotFoundTitle": "ユーザーが見つかりません | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "{name}の視聴アクティビティとプロフィールを表示。",
+    "userProfileOgTitle": "{name} - Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "アプリ未インストール",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "ゲスト",
+    "member": "メンバー",
+    "roomHost": "ルームホスト",
+    "user": "ユーザー"
   }
 }

--- a/src/i18n/messages/ja/party.json
+++ b/src/i18n/messages/ja/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "ホストがリクエストを拒否しました",
     "hostLeftRoom": "ホストがルームを退出しました",
     "failedCreateRoom": "ルームの作成に失敗しました",
-    "hostEndedParty": "ホストがパーティーを終了しました。"
+    "hostEndedParty": "ホストがパーティーを終了しました。",
+    "mediaError": "メディアエラー: {message}",
+    "unknownMediaError": "不明なエラーが発生しました"
   },
   "desktop": {
     "coWatchingLiveStream": "ライブ配信を一緒に視聴中",
@@ -249,5 +251,9 @@
     "sketchFor": "{name}のスケッチ",
     "soundsFor": "{name}のサウンド",
     "chatFor": "{name}のチャット"
+  },
+  "aria": {
+    "partySidebar": "パーティーサイドバー",
+    "sendReaction": "{emoji} リアクションを送信"
   }
 }

--- a/src/i18n/messages/ja/search.json
+++ b/src/i18n/messages/ja/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "結果が見つかりません",
     "noResultsArchiveHint": "アーカイブに一致するものが見つかりませんでした。別のタイトルやキーワードで検索してください。",
     "editQueryAriaLabel": "検索クエリを編集",
-    "searchingAriaLabel": "検索中..."
+    "searchingAriaLabel": "検索中...",
+    "viewDetailsFor": "{title} の詳細を表示"
   },
   "continueWatching": {
     "title": "視聴を続ける",

--- a/src/i18n/messages/ja/watch.json
+++ b/src/i18n/messages/ja/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "オフライン",
     "vault": "保管庫",
     "yourDownloads": "ダウンロード済みコンテンツ",
-    "downloadsCount": "{count}件のダウンロード",
+    "downloadsCount": "{count, plural, other {# ダウンロード}}",
     "availableOffline": "オフラインで視聴可能",
     "emptyTitle": "保管庫は空です",
     "emptyDescription": "安全なダウンロードがここに表示されます",

--- a/src/i18n/messages/ko/common.json
+++ b/src/i18n/messages/ko/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "언어",
-    "description": "선호하는 언어를 선택하세요",
-    "closeMenu": "언어 메뉴 닫기"
+    "description": "선호하는 언어를 선택하세요"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "내 관심목록 | Watch Rudra",
     "watchlistDescription": "나중에 볼 영화와 TV 프로그램을 관리하세요.",
     "watchPartyTitle": "워치 파티 | Watch Rudra",
-    "watchPartyDescription": "친구들과 함께 실시간으로 시청하세요."
+    "watchPartyDescription": "친구들과 함께 실시간으로 시청하세요.",
+    "userNotFoundTitle": "사용자를 찾을 수 없습니다 | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "{name}의 시청 활동 및 프로필을 확인하세요.",
+    "userProfileOgTitle": "{name} - Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "앱 미설치",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "게스트",
+    "member": "멤버",
+    "roomHost": "방장",
+    "user": "사용자"
   }
 }

--- a/src/i18n/messages/ko/party.json
+++ b/src/i18n/messages/ko/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "호스트가 요청을 거절했습니다",
     "hostLeftRoom": "호스트가 방을 나갔습니다",
     "failedCreateRoom": "방 생성에 실패했습니다",
-    "hostEndedParty": "호스트가 파티를 종료했습니다."
+    "hostEndedParty": "호스트가 파티를 종료했습니다.",
+    "mediaError": "미디어 오류: {message}",
+    "unknownMediaError": "알 수 없는 오류가 발생했습니다"
   },
   "desktop": {
     "coWatchingLiveStream": "라이브 스트림 함께 시청 중",
@@ -249,5 +251,9 @@
     "sketchFor": "{name}의 스케치",
     "soundsFor": "{name}의 소리",
     "chatFor": "{name}의 채팅"
+  },
+  "aria": {
+    "partySidebar": "파티 사이드바",
+    "sendReaction": "{emoji} 반응 보내기"
   }
 }

--- a/src/i18n/messages/ko/search.json
+++ b/src/i18n/messages/ko/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "결과를 찾을 수 없습니다",
     "noResultsArchiveHint": "아카이브에서 일치하는 항목을 찾을 수 없습니다. 다른 제목이나 키워드로 검색해 보세요.",
     "editQueryAriaLabel": "검색어 수정",
-    "searchingAriaLabel": "검색 중..."
+    "searchingAriaLabel": "검색 중...",
+    "viewDetailsFor": "{title} 상세 보기"
   },
   "continueWatching": {
     "title": "이어서 보기",

--- a/src/i18n/messages/ko/watch.json
+++ b/src/i18n/messages/ko/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "오프라인",
     "vault": "보관함",
     "yourDownloads": "다운로드한 콘텐츠",
-    "downloadsCount": "{count}개 다운로드",
+    "downloadsCount": "{count, plural, other {다운로드 #개}}",
     "availableOffline": "오프라인 시청 가능",
     "emptyTitle": "보관함이 비어 있습니다",
     "emptyDescription": "보안 다운로드가 여기에 표시됩니다",

--- a/src/i18n/messages/pt/common.json
+++ b/src/i18n/messages/pt/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "Idioma",
-    "description": "Escolha seu idioma preferido",
-    "closeMenu": "Fechar menu de idioma"
+    "description": "Escolha seu idioma preferido"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "Minha Lista | Watch Rudra",
     "watchlistDescription": "Acompanhe os filmes e séries que você quer assistir depois.",
     "watchPartyTitle": "Watch Party | Watch Rudra",
-    "watchPartyDescription": "Junte-se aos seus amigos e assistam juntos em tempo real."
+    "watchPartyDescription": "Junte-se aos seus amigos e assistam juntos em tempo real.",
+    "userNotFoundTitle": "Usuário não encontrado | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "Veja a atividade e o perfil de {name} no Watch Rudra.",
+    "userProfileOgTitle": "{name} no Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "App não instalado",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "Convidado",
+    "member": "Membro",
+    "roomHost": "Anfitrião",
+    "user": "Usuário"
   }
 }

--- a/src/i18n/messages/pt/party.json
+++ b/src/i18n/messages/pt/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "O anfitrião rejeitou sua solicitação",
     "hostLeftRoom": "O anfitrião saiu da sala",
     "failedCreateRoom": "Falha ao criar sala",
-    "hostEndedParty": "O anfitrião encerrou a festa."
+    "hostEndedParty": "O anfitrião encerrou a festa.",
+    "mediaError": "Erro de mídia: {message}",
+    "unknownMediaError": "Ocorreu um erro desconhecido"
   },
   "desktop": {
     "coWatchingLiveStream": "Assistindo transmissão ao vivo juntos",
@@ -249,5 +251,9 @@
     "sketchFor": "Desenho para {name}",
     "soundsFor": "Sons para {name}",
     "chatFor": "Chat para {name}"
+  },
+  "aria": {
+    "partySidebar": "Barra lateral da festa",
+    "sendReaction": "Enviar reação {emoji}"
   }
 }

--- a/src/i18n/messages/pt/search.json
+++ b/src/i18n/messages/pt/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "Nenhum Resultado Encontrado",
     "noResultsArchiveHint": "Não encontramos correspondências em nossos arquivos. Tente buscar um título ou palavra-chave diferente.",
     "editQueryAriaLabel": "Editar busca",
-    "searchingAriaLabel": "Buscando..."
+    "searchingAriaLabel": "Buscando...",
+    "viewDetailsFor": "Ver detalhes de {title}"
   },
   "continueWatching": {
     "title": "Continuar Assistindo",

--- a/src/i18n/messages/pt/watch.json
+++ b/src/i18n/messages/pt/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "OFFLINE",
     "vault": "COFRE",
     "yourDownloads": "Seu Conteúdo Baixado",
-    "downloadsCount": "{count} Download(s)",
+    "downloadsCount": "{count, plural, one {# Download} other {# Downloads}}",
     "availableOffline": "Disponível para visualização offline",
     "emptyTitle": "Cofre está vazio",
     "emptyDescription": "Downloads seguros aparecerão aqui",

--- a/src/i18n/messages/ru/common.json
+++ b/src/i18n/messages/ru/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "Язык",
-    "description": "Выберите предпочитаемый язык",
-    "closeMenu": "Закрыть меню языка"
+    "description": "Выберите предпочитаемый язык"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "Мой Список | Watch Rudra",
     "watchlistDescription": "Отслеживайте фильмы и сериалы, которые хотите посмотреть позже.",
     "watchPartyTitle": "Совместный Просмотр | Watch Rudra",
-    "watchPartyDescription": "Присоединяйтесь к друзьям и смотрите вместе в реальном времени."
+    "watchPartyDescription": "Присоединяйтесь к друзьям и смотрите вместе в реальном времени.",
+    "userNotFoundTitle": "Пользователь не найден | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "Просмотр активности и профиля {name} на Watch Rudra.",
+    "userProfileOgTitle": "{name} на Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "Приложение не установлено",
@@ -215,5 +218,11 @@
     "mb": "МБ",
     "gb": "ГБ",
     "tb": "ТБ"
+  },
+  "fallbacks": {
+    "guest": "Гость",
+    "member": "Участник",
+    "roomHost": "Хост комнаты",
+    "user": "Пользователь"
   }
 }

--- a/src/i18n/messages/ru/party.json
+++ b/src/i18n/messages/ru/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "Организатор отклонил ваш запрос",
     "hostLeftRoom": "Организатор покинул комнату",
     "failedCreateRoom": "Не удалось создать комнату",
-    "hostEndedParty": "Организатор завершил вечеринку."
+    "hostEndedParty": "Организатор завершил вечеринку.",
+    "mediaError": "Ошибка медиа: {message}",
+    "unknownMediaError": "Произошла неизвестная ошибка"
   },
   "desktop": {
     "coWatchingLiveStream": "Совместный просмотр трансляции",
@@ -249,5 +251,9 @@
     "sketchFor": "Рисование для {name}",
     "soundsFor": "Звуки для {name}",
     "chatFor": "Чат для {name}"
+  },
+  "aria": {
+    "partySidebar": "Боковая панель вечеринки",
+    "sendReaction": "Отправить реакцию {emoji}"
   }
 }

--- a/src/i18n/messages/ru/search.json
+++ b/src/i18n/messages/ru/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "Результатов не найдено",
     "noResultsArchiveHint": "Мы не нашли совпадений в наших архивах. Попробуйте поискать другое название или ключевое слово.",
     "editQueryAriaLabel": "Редактировать поисковый запрос",
-    "searchingAriaLabel": "Идёт поиск..."
+    "searchingAriaLabel": "Идёт поиск...",
+    "viewDetailsFor": "Подробнее о {title}"
   },
   "continueWatching": {
     "title": "Продолжить просмотр",

--- a/src/i18n/messages/ru/watch.json
+++ b/src/i18n/messages/ru/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "ОФЛАЙН",
     "vault": "ХРАНИЛИЩЕ",
     "yourDownloads": "Ваш загруженный контент",
-    "downloadsCount": "{count} загрузка(и)",
+    "downloadsCount": "{count, plural, one {# загрузка} few {# загрузки} many {# загрузок} other {# загрузок}}",
     "availableOffline": "Доступно для офлайн-просмотра",
     "emptyTitle": "Хранилище пусто",
     "emptyDescription": "Безопасные загрузки появятся здесь",

--- a/src/i18n/messages/th/common.json
+++ b/src/i18n/messages/th/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "ภาษา",
-    "description": "เลือกภาษาที่คุณต้องการ",
-    "closeMenu": "ปิดเมนูภาษา"
+    "description": "เลือกภาษาที่คุณต้องการ"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "รายการดูของฉัน | Watch Rudra",
     "watchlistDescription": "ติดตามภาพยนตร์และซีรีส์ที่คุณต้องการดูทีหลัง",
     "watchPartyTitle": "ปาร์ตี้ดูหนัง | Watch Rudra",
-    "watchPartyDescription": "เข้าร่วมกับเพื่อนและดูด้วยกันแบบเรียลไทม์"
+    "watchPartyDescription": "เข้าร่วมกับเพื่อนและดูด้วยกันแบบเรียลไทม์",
+    "userNotFoundTitle": "ไม่พบผู้ใช้ | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "ดูกิจกรรมการรับชมและโปรไฟล์ของ {name}",
+    "userProfileOgTitle": "{name} บน Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "ยังไม่ได้ติดตั้งแอป",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "ผู้เยี่ยมชม",
+    "member": "สมาชิก",
+    "roomHost": "เจ้าของห้อง",
+    "user": "ผู้ใช้"
   }
 }

--- a/src/i18n/messages/th/party.json
+++ b/src/i18n/messages/th/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "โฮสต์ปฏิเสธคำขอของคุณ",
     "hostLeftRoom": "โฮสต์ออกจากห้องแล้ว",
     "failedCreateRoom": "ไม่สามารถสร้างห้องได้",
-    "hostEndedParty": "โฮสต์ได้สิ้นสุดปาร์ตี้แล้ว"
+    "hostEndedParty": "โฮสต์ได้สิ้นสุดปาร์ตี้แล้ว",
+    "mediaError": "ข้อผิดพลาดสื่อ: {message}",
+    "unknownMediaError": "เกิดข้อผิดพลาดที่ไม่ทราบสาเหตุ"
   },
   "desktop": {
     "coWatchingLiveStream": "ดูไลฟ์สตรีมด้วยกัน",
@@ -249,5 +251,9 @@
     "sketchFor": "วาดสำหรับ {name}",
     "soundsFor": "เสียงสำหรับ {name}",
     "chatFor": "แชทสำหรับ {name}"
+  },
+  "aria": {
+    "partySidebar": "แถบด้านข้างปาร์ตี้",
+    "sendReaction": "ส่งรีแอคชัน {emoji}"
   }
 }

--- a/src/i18n/messages/th/search.json
+++ b/src/i18n/messages/th/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "ไม่พบผลลัพธ์",
     "noResultsArchiveHint": "เราไม่พบรายการที่ตรงกันในคลัง ลองค้นหาชื่อเรื่องหรือคำสำคัญอื่น",
     "editQueryAriaLabel": "แก้ไขคำค้นหา",
-    "searchingAriaLabel": "กำลังค้นหา..."
+    "searchingAriaLabel": "กำลังค้นหา...",
+    "viewDetailsFor": "ดูรายละเอียดของ {title}"
   },
   "continueWatching": {
     "title": "ดูต่อ",

--- a/src/i18n/messages/th/watch.json
+++ b/src/i18n/messages/th/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "ออฟไลน์",
     "vault": "ตู้เซฟ",
     "yourDownloads": "เนื้อหาที่ดาวน์โหลดของคุณ",
-    "downloadsCount": "{count} ดาวน์โหลด",
+    "downloadsCount": "{count, plural, other {# ดาวน์โหลด}}",
     "availableOffline": "พร้อมดูแบบออฟไลน์",
     "emptyTitle": "ตู้เซฟว่างเปล่า",
     "emptyDescription": "ดาวน์โหลดที่ปลอดภัยจะปรากฏที่นี่",

--- a/src/i18n/messages/tr/common.json
+++ b/src/i18n/messages/tr/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "Dil",
-    "description": "Tercih ettiğiniz dili seçin",
-    "closeMenu": "Dil menüsünü kapat"
+    "description": "Tercih ettiğiniz dili seçin"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "İzleme Listem | Watch Rudra",
     "watchlistDescription": "Daha sonra izlemek istediğiniz film ve dizileri takip edin.",
     "watchPartyTitle": "İzleme Partisi | Watch Rudra",
-    "watchPartyDescription": "Arkadaşlarınıza katılın ve gerçek zamanlı birlikte izleyin."
+    "watchPartyDescription": "Arkadaşlarınıza katılın ve gerçek zamanlı birlikte izleyin.",
+    "userNotFoundTitle": "Kullanıcı bulunamadı | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "{name} adlı kullanıcının izleme etkinliğini ve profilini görüntüleyin.",
+    "userProfileOgTitle": "{name} - Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "Uygulama yüklü değil",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "Misafir",
+    "member": "Üye",
+    "roomHost": "Oda Sahibi",
+    "user": "Kullanıcı"
   }
 }

--- a/src/i18n/messages/tr/party.json
+++ b/src/i18n/messages/tr/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "Ev sahibi isteğinizi reddetti",
     "hostLeftRoom": "Ev sahibi odadan ayrıldı",
     "failedCreateRoom": "Oda oluşturulamadı",
-    "hostEndedParty": "Ev sahibi partiyi sonlandırdı."
+    "hostEndedParty": "Ev sahibi partiyi sonlandırdı.",
+    "mediaError": "Medya Hatası: {message}",
+    "unknownMediaError": "Bilinmeyen bir hata oluştu"
   },
   "desktop": {
     "coWatchingLiveStream": "Birlikte Canlı Yayın İzleniyor",
@@ -249,5 +251,9 @@
     "sketchFor": "{name} için çizim",
     "soundsFor": "{name} için sesler",
     "chatFor": "{name} için sohbet"
+  },
+  "aria": {
+    "partySidebar": "Parti kenar çubuğu",
+    "sendReaction": "{emoji} tepkisi gönder"
   }
 }

--- a/src/i18n/messages/tr/search.json
+++ b/src/i18n/messages/tr/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "Sonuç Bulunamadı",
     "noResultsArchiveHint": "Arşivlerimizde eşleşme bulamadık. Farklı bir başlık veya anahtar kelime aramayı deneyin.",
     "editQueryAriaLabel": "Arama sorgusunu düzenle",
-    "searchingAriaLabel": "Aranıyor..."
+    "searchingAriaLabel": "Aranıyor...",
+    "viewDetailsFor": "{title} detaylarını görüntüle"
   },
   "continueWatching": {
     "title": "İzlemeye Devam Et",

--- a/src/i18n/messages/tr/watch.json
+++ b/src/i18n/messages/tr/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "ÇEVRİMDIŞI",
     "vault": "KASA",
     "yourDownloads": "İndirilen İçerikleriniz",
-    "downloadsCount": "{count} İndirme",
+    "downloadsCount": "{count, plural, one {# İndirme} other {# İndirme}}",
     "availableOffline": "Çevrimdışı izleme için kullanılabilir",
     "emptyTitle": "Kasa boş",
     "emptyDescription": "Güvenli indirmeler burada görünecek",

--- a/src/i18n/messages/zh/common.json
+++ b/src/i18n/messages/zh/common.json
@@ -13,8 +13,7 @@
   },
   "language": {
     "title": "语言",
-    "description": "选择您的首选语言",
-    "closeMenu": "关闭语言菜单"
+    "description": "选择您的首选语言"
   },
   "notFound": {
     "title": "404",
@@ -166,7 +165,11 @@
     "watchlistTitle": "我的观看列表 | Watch Rudra",
     "watchlistDescription": "跟踪您想稍后观看的电影和电视节目。",
     "watchPartyTitle": "观影派对 | Watch Rudra",
-    "watchPartyDescription": "加入朋友，实时一起观看。"
+    "watchPartyDescription": "加入朋友，实时一起观看。",
+    "userNotFoundTitle": "未找到用户 | Watch Rudra",
+    "userProfileTitle": "{name} (@{username}) | Watch Rudra",
+    "userProfileDescription": "查看 {name} 的观看活动和个人资料。",
+    "userProfileOgTitle": "{name} - Watch Rudra"
   },
   "desktopApp": {
     "notInstalled": "应用未安装",
@@ -215,5 +218,11 @@
     "mb": "MB",
     "gb": "GB",
     "tb": "TB"
+  },
+  "fallbacks": {
+    "guest": "访客",
+    "member": "成员",
+    "roomHost": "房间主持人",
+    "user": "用户"
   }
 }

--- a/src/i18n/messages/zh/party.json
+++ b/src/i18n/messages/zh/party.json
@@ -198,7 +198,9 @@
     "hostRejected": "主持人拒绝了你的请求",
     "hostLeftRoom": "主持人离开了房间",
     "failedCreateRoom": "创建房间失败",
-    "hostEndedParty": "主持人已结束派对。"
+    "hostEndedParty": "主持人已结束派对。",
+    "mediaError": "媒体错误：{message}",
+    "unknownMediaError": "发生未知错误"
   },
   "desktop": {
     "coWatchingLiveStream": "一起观看直播",
@@ -249,5 +251,9 @@
     "sketchFor": "{name} 的画板",
     "soundsFor": "{name} 的音效",
     "chatFor": "{name} 的聊天"
+  },
+  "aria": {
+    "partySidebar": "派对侧边栏",
+    "sendReaction": "发送 {emoji} 反应"
   }
 }

--- a/src/i18n/messages/zh/search.json
+++ b/src/i18n/messages/zh/search.json
@@ -20,7 +20,8 @@
     "noResultsArchive": "未找到结果",
     "noResultsArchiveHint": "我们在档案中未找到匹配项。请尝试搜索不同的标题或关键词。",
     "editQueryAriaLabel": "编辑搜索查询",
-    "searchingAriaLabel": "搜索中..."
+    "searchingAriaLabel": "搜索中...",
+    "viewDetailsFor": "查看 {title} 的详情"
   },
   "continueWatching": {
     "title": "继续观看",

--- a/src/i18n/messages/zh/watch.json
+++ b/src/i18n/messages/zh/watch.json
@@ -109,7 +109,7 @@
     "pageTitle": "离线",
     "vault": "保险库",
     "yourDownloads": "您的下载内容",
-    "downloadsCount": "{count} 个下载",
+    "downloadsCount": "{count, plural, other {# 个下载}}",
     "availableOffline": "可离线观看",
     "emptyTitle": "保险库为空",
     "emptyDescription": "安全下载将显示在此处",

--- a/src/providers/html-lang-setter.tsx
+++ b/src/providers/html-lang-setter.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect } from 'react';
 
+const RTL_LOCALES = ['ar'];
+
 export function HtmlLangSetter({ locale }: { locale: string }) {
   useEffect(() => {
     document.documentElement.lang = locale;
-    document.documentElement.dir = locale === 'ar' ? 'rtl' : 'ltr';
+    document.documentElement.dir = RTL_LOCALES.includes(locale) ? 'rtl' : 'ltr';
   }, [locale]);
 
   return null;

--- a/src/providers/intl-client-wrapper.tsx
+++ b/src/providers/intl-client-wrapper.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { type AbstractIntlMessages, NextIntlClientProvider } from 'next-intl';
+
+function onError(error: { code: string; message: string }) {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(`[next-intl] ${error.code}: ${error.message}`);
+  }
+}
+
+function getMessageFallback({
+  namespace,
+  key,
+}: {
+  namespace?: string;
+  key: string;
+  error: { code: string };
+}) {
+  const leafKey = key.split('.').pop() ?? key;
+  return namespace ? `${namespace}.${leafKey}` : leafKey;
+}
+
+export function IntlClientWrapper({
+  locale,
+  messages,
+  children,
+}: {
+  locale: string;
+  messages: AbstractIntlMessages;
+  children: React.ReactNode;
+}) {
+  return (
+    <NextIntlClientProvider
+      locale={locale}
+      messages={messages}
+      onError={onError}
+      getMessageFallback={getMessageFallback}
+    >
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/src/providers/intl-provider.tsx
+++ b/src/providers/intl-provider.tsx
@@ -1,6 +1,7 @@
-import { NextIntlClientProvider } from 'next-intl';
+import type { AbstractIntlMessages } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
 import { HtmlLangSetter } from './html-lang-setter';
+import { IntlClientWrapper } from './intl-client-wrapper';
 
 export async function IntlProvider({
   children,
@@ -8,19 +9,22 @@ export async function IntlProvider({
   children: React.ReactNode;
 }) {
   let locale = 'en';
-  let messages = {};
+  let messages: AbstractIntlMessages = {};
 
   try {
     locale = await getLocale();
     messages = await getMessages();
-  } catch {
-    // Fallback to English if locale detection fails
+  } catch (err) {
+    console.error(
+      '[IntlProvider] Failed to load messages, falling back to en:',
+      err,
+    );
   }
 
   return (
-    <NextIntlClientProvider locale={locale} messages={messages}>
+    <IntlClientWrapper locale={locale} messages={messages}>
       <HtmlLangSetter locale={locale} />
       {children}
-    </NextIntlClientProvider>
+    </IntlClientWrapper>
   );
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,61 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-export default function proxy(_req: NextRequest) {
+const COOKIE_NAME = 'NEXT_LOCALE';
+const SUPPORTED = new Set([
+  'en',
+  'hi',
+  'es',
+  'fr',
+  'ja',
+  'ko',
+  'de',
+  'pt',
+  'ar',
+  'ru',
+  'zh',
+  'it',
+  'tr',
+  'th',
+]);
+const DEFAULT_LOCALE = 'en';
+
+function getPreferredLocale(acceptLanguage: string | null): string {
+  if (!acceptLanguage) return DEFAULT_LOCALE;
+  const preferred = acceptLanguage
+    .split(',')
+    .map((part) => {
+      const [lang, q] = part.trim().split(';q=');
+      return {
+        lang: lang.trim().toLowerCase(),
+        q: q ? Number.parseFloat(q) : 1,
+      };
+    })
+    .sort((a, b) => b.q - a.q);
+
+  for (const { lang } of preferred) {
+    if (SUPPORTED.has(lang)) return lang;
+    const prefix = lang.split('-')[0];
+    if (SUPPORTED.has(prefix)) return prefix;
+  }
+  return DEFAULT_LOCALE;
+}
+
+export default function proxy(req: NextRequest) {
+  // Check raw Cookie header to avoid triggering dynamic route behavior
+  const rawCookie = req.headers.get('cookie') || '';
+  const hasLocale = rawCookie.includes(`${COOKIE_NAME}=`);
+
+  if (!hasLocale) {
+    const locale = getPreferredLocale(req.headers.get('accept-language'));
+    const response = NextResponse.next();
+    response.cookies.set(COOKIE_NAME, locale, {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 365,
+      sameSite: 'lax',
+    });
+    return response;
+  }
   return NextResponse.next();
 }
 

--- a/tests/e2e/i18n-locale-switching.spec.ts
+++ b/tests/e2e/i18n-locale-switching.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+const COOKIE_NAME = 'NEXT_LOCALE';
+
+test.describe('i18n Locale Switching', () => {
+  test('defaults to English when no locale cookie is set', async ({ page }) => {
+    await page.goto('/');
+    const html = page.locator('html');
+    await expect(html).toHaveAttribute('lang', 'en');
+    await expect(html).toHaveAttribute('dir', 'ltr');
+  });
+
+  test('respects NEXT_LOCALE cookie for French', async ({ page, context }) => {
+    await context.addCookies([
+      { name: COOKIE_NAME, value: 'fr', url: 'http://localhost:3000' },
+    ]);
+    await page.goto('/');
+    const html = page.locator('html');
+    await expect(html).toHaveAttribute('lang', 'fr');
+    await expect(html).toHaveAttribute('dir', 'ltr');
+  });
+
+  test('sets dir="rtl" for Arabic locale', async ({ page, context }) => {
+    await context.addCookies([
+      { name: COOKIE_NAME, value: 'ar', url: 'http://localhost:3000' },
+    ]);
+    await page.goto('/');
+    const html = page.locator('html');
+    await expect(html).toHaveAttribute('lang', 'ar');
+    await expect(html).toHaveAttribute('dir', 'rtl');
+  });
+
+  test('falls back to English for invalid locale cookie', async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([
+      { name: COOKIE_NAME, value: 'xx', url: 'http://localhost:3000' },
+    ]);
+    await page.goto('/');
+    const html = page.locator('html');
+    await expect(html).toHaveAttribute('lang', 'en');
+  });
+
+  test('middleware sets cookie from Accept-Language header on first visit', async ({
+    page,
+  }) => {
+    // Set Accept-Language to Japanese
+    await page.setExtraHTTPHeaders({ 'Accept-Language': 'ja,en;q=0.5' });
+    await page.goto('/');
+
+    const cookies = await page.context().cookies();
+    const localeCookie = cookies.find((c) => c.name === COOKIE_NAME);
+    expect(localeCookie).toBeDefined();
+    expect(localeCookie!.value).toBe('ja');
+  });
+
+  test('middleware does not overwrite existing locale cookie', async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([
+      { name: COOKIE_NAME, value: 'ko', url: 'http://localhost:3000' },
+    ]);
+    await page.setExtraHTTPHeaders({ 'Accept-Language': 'fr,en;q=0.5' });
+    await page.goto('/');
+
+    const cookies = await page.context().cookies();
+    const localeCookie = cookies.find((c) => c.name === COOKIE_NAME);
+    expect(localeCookie!.value).toBe('ko');
+  });
+});

--- a/tests/features/watch-party/components/interactions/EmojiReactions.test.tsx
+++ b/tests/features/watch-party/components/interactions/EmojiReactions.test.tsx
@@ -24,8 +24,9 @@ describe('EmojiReactions', () => {
 
   it('renders quick emojis', () => {
     render(<EmojiReactions rtmSendMessage={mockRtmSendMessage} />);
-    expect(screen.getByLabelText('Send ❤️ reaction')).toBeInTheDocument();
-    expect(screen.getByLabelText('Send 😂 reaction')).toBeInTheDocument();
+    // All emoji buttons share the same mocked aria-label key
+    const buttons = screen.getAllByLabelText('sendReaction');
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
   });
 
   it('calls handleTriggerEmoji when a quick emoji is clicked', async () => {
@@ -41,7 +42,7 @@ describe('EmojiReactions', () => {
     });
 
     render(<EmojiReactions rtmSendMessage={mockRtmSendMessage} />);
-    fireEvent.click(screen.getByLabelText('Send ❤️ reaction'));
+    fireEvent.click(screen.getAllByLabelText('sendReaction')[0]);
     expect(mockHandleTrigger).toHaveBeenCalledWith('❤️');
   });
 });


### PR DESCRIPTION
Full i18n architecture audit and implementation of all recommended improvements across 14 locales and 900+ translation keys.                     
                                                                                                                                                   
  ## Changes                                                                                                                                       
                                                                                                                                                   
  ### RTL Support                                                                                                                                  
  - CSS logical property overrides for Arabic (\`dir=rtl\`) — mirrors margins, paddings, positioning, borders, text alignment                      
                                                                                                                                                   
  ### Error Handling & Type Safety                                                                                                                 
  - \`onError\` + \`getMessageFallback\` on \`NextIntlClientProvider\` via dedicated client wrapper                                                
  - \`global.d.ts\` augmenting \`IntlMessages\` for compile-time translation key validation                                                        
                                                                                                                                                   
  ### Date/Number Formatting                                                                                                                       
  - Replaced all \`toLocaleDateString([])\` calls with \`useFormatter()\` across 8 files                                                           
  - Dates now format per app locale instead of browser locale                                                                                      
                                                                                                                                                   
  ### Localized Page Metadata                                                                                                                      
  - 8 pages converted from static \`metadata\` to \`generateMetadata\` + \`getTranslations\`                                                       
  - User profile metadata with interpolation across all 14 locales                                                                                 
                                                                                                                                                   
  ### Accept-Language Detection                                                                                                                    
  - \`proxy.ts\` auto-detects locale from \`Accept-Language\` header on first visit                                                                
  - Sets \`NEXT_LOCALE\` cookie to best-matching supported locale                                                                                  
                                                                                                                                                   
  ### Hardcoded String Fixes                                                                                                                       
  - Localized aria-labels (ActiveWatchParty, SubtitleOverlay, EmojiReactions, search-results)                                                      
  - Localized useAgora media error toast                                                                                                           
  - Added fallback keys (guest, member, roomHost) across all locales                                                                               
                                                                                                                                                   
  ### ICU Plural Fix                                                                                                                               
  - Fixed \`downloadsCount\` from broken \`(s)\` to proper ICU plural syntax with locale-appropriate categories                                    
                                                                                                                                                   
  ### Language Switcher                                                                                                                            
  - Extracted reusable \`LanguageSwitcher\` component                                                                                              
  - Added to login and signup pages (top-right)                                                                                                    
  - Profile route refactored to use shared component (removed duplicate code)                                                                      
                                                                                                                                                   
  ### CI/CD                                                                                                                                        
  - Added \"Validate i18n translations\" step to all 4 deploy workflows                                                                            
  - Blocks deployment if key parity, empty values, or ICU placeholders fail                                                                        
                                                                                                                                                   
  ### Infrastructure                                                                                                                               
  - E2E locale switching tests (cookie, RTL, Accept-Language, fallback)                                                                            
  - TMS extraction script (\`scripts/extract-translations.mjs\`)                                                                                   
                                                                                                                                                   
  ## Testing                                                                                                                                       
  - ✅ Build passes                                                                                                                                
  - ✅ Biome: 0 errors                                                                                                                             
  - ✅ 105/105 test files, 1776/1776 tests passed                                                                                                  
  - ✅ 409/409 i18n integrity tests passed" 2>&1   