### PR TITLE
Sidebar navigation, layout redesign & search bug fix

### DIFF
--- a/src/app/(protected)/(main)/ask-ai/page.tsx
+++ b/src/app/(protected)/(main)/ask-ai/page.tsx
@@ -1,0 +1,12 @@
+export default function AskAiPage() {
+  return (
+    <main className="flex-grow flex flex-col items-center justify-center p-8">
+      <h1 className="font-headline text-4xl font-black uppercase tracking-tighter text-foreground mb-4">
+        Ask AI
+      </h1>
+      <p className="text-sm text-foreground/40 font-headline uppercase tracking-widest">
+        Coming soon
+      </p>
+    </main>
+  );
+}

--- a/src/app/(protected)/(main)/changelog/page.tsx
+++ b/src/app/(protected)/(main)/changelog/page.tsx
@@ -1,0 +1,67 @@
+import { getTranslations } from 'next-intl/server';
+import { ReleaseList } from '@/app/(public)/whats-new/release-list';
+
+export async function generateMetadata() {
+  const t = await getTranslations('common.whatsNew');
+  return { title: t('title'), description: t('description') };
+}
+
+interface Release {
+  id: number;
+  name: string;
+  tag_name: string;
+  published_at: string;
+  body: string;
+  html_url: string;
+  author: { login: string; avatar_url: string };
+}
+
+export default async function ChangelogPage() {
+  const t = await getTranslations('common.whatsNew');
+  const headers: HeadersInit = {};
+  const token = process.env.WATCH_RUDRA_GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const res = await fetch(
+    'https://api.github.com/repos/rudra-sah00/watch-rudra/releases',
+    { headers, next: { revalidate: 3600 } },
+  );
+
+  let releases: Release[] = [];
+  if (res.ok) {
+    releases = await res.json();
+  }
+
+  return (
+    <main className="min-h-full bg-background pb-32">
+      {/* Hero Header */}
+      <div className="mb-12 bg-neo-green relative overflow-hidden rounded-2xl">
+        <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />
+        <div className="absolute top-10 left-1/4 w-24 h-24 bg-neo-yellow border-[4px] border-border opacity-30 rotate-12" />
+
+        <div className="container mx-auto px-6 py-12 md:px-10 relative z-10">
+          <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-8">
+            <div>
+              <h1 className="text-6xl md:text-8xl lg:text-9xl font-black tracking-tighter text-white font-headline uppercase leading-none mb-4">
+                WHAT&apos;S
+                <br />
+                <span className="bg-background text-foreground px-4 inline-block border-[4px] border-border -rotate-1 ml-2 mt-2">
+                  NEW
+                </span>
+              </h1>
+              <p className="font-headline font-bold uppercase tracking-widest text-foreground bg-background inline-block px-4 py-2 border-[3px] border-border">
+                {t('description')}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="container mx-auto px-6 md:px-10">
+        <ReleaseList releases={releases} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(protected)/(main)/changelog/page.tsx
+++ b/src/app/(protected)/(main)/changelog/page.tsx
@@ -35,7 +35,7 @@ export default async function ChangelogPage() {
   }
 
   return (
-    <main className="min-h-full bg-background pb-32">
+    <main className="min-h-full pb-32">
       {/* Hero Header */}
       <div className="mb-12 bg-neo-green relative overflow-hidden rounded-2xl">
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />

--- a/src/app/(protected)/(main)/continue-watching/ContinueWatchingClient.tsx
+++ b/src/app/(protected)/(main)/continue-watching/ContinueWatchingClient.tsx
@@ -20,18 +20,22 @@ export default function ContinueWatchingClient() {
   const t = useTranslations('search');
 
   return (
-    <main className="min-h-[calc(100vh-80px)] bg-background pb-32 animate-in fade-in">
+    <main className="min-h-full bg-background pb-32 animate-in fade-in">
       {/* Hero Header */}
-      <div className="border-b-[4px] border-border mb-12 bg-neo-blue relative overflow-hidden">
+      <div className="mb-12 bg-neo-blue relative overflow-hidden rounded-2xl">
         {/* Abstract background shapes */}
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />
         <div className="absolute top-10 left-1/4 w-24 h-24 bg-neo-yellow border-[4px] border-border opacity-30 rotate-12" />
 
         <div className="container mx-auto px-6 py-12 md:px-10 relative z-10">
-          <div className="flex flex-col xl:flex-row xl:items-end justify-between gap-8">
+          <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-8">
             <div>
               <h1 className="text-6xl md:text-8xl lg:text-9xl font-black tracking-tighter text-primary-foreground font-headline uppercase leading-none mb-4 min-w-0">
-                {t('continueWatching.title')}
+                {t('continueWatching.title').split(' ')[0]}
+                <br />
+                <span className="bg-background text-foreground px-4 inline-block border-[4px] border-border -rotate-1 ml-2 mt-2">
+                  {t('continueWatching.title').split(' ').slice(1).join(' ')}
+                </span>
               </h1>
               <p className="font-headline font-bold uppercase tracking-widest text-foreground bg-background inline-block px-4 py-2 border-[3px] border-border">
                 {t('continueWatching.subtitle')}

--- a/src/app/(protected)/(main)/continue-watching/ContinueWatchingClient.tsx
+++ b/src/app/(protected)/(main)/continue-watching/ContinueWatchingClient.tsx
@@ -20,7 +20,7 @@ export default function ContinueWatchingClient() {
   const t = useTranslations('search');
 
   return (
-    <main className="min-h-full bg-background pb-32 animate-in fade-in">
+    <main className="min-h-full pb-32 animate-in fade-in">
       {/* Hero Header */}
       <div className="mb-12 bg-neo-blue relative overflow-hidden rounded-2xl">
         {/* Abstract background shapes */}

--- a/src/app/(protected)/(main)/continue-watching/loading.tsx
+++ b/src/app/(protected)/(main)/continue-watching/loading.tsx
@@ -1,6 +1,6 @@
 export default function ContinueWatchingLoading() {
   return (
-    <main className="min-h-[calc(100vh-80px)] bg-background pb-32">
+    <main className="min-h-[calc(100vh-80px)] pb-32">
       {/* Hero Header - exact match */}
       <div className="mb-12 bg-neo-blue relative overflow-hidden rounded-2xl">
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />

--- a/src/app/(protected)/(main)/continue-watching/loading.tsx
+++ b/src/app/(protected)/(main)/continue-watching/loading.tsx
@@ -2,7 +2,7 @@ export default function ContinueWatchingLoading() {
   return (
     <main className="min-h-[calc(100vh-80px)] bg-background pb-32">
       {/* Hero Header - exact match */}
-      <div className="border-b-[4px] border-border mb-12 bg-neo-blue relative overflow-hidden">
+      <div className="mb-12 bg-neo-blue relative overflow-hidden rounded-2xl">
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />
         <div className="absolute top-10 left-1/4 w-24 h-24 bg-neo-yellow border-[4px] border-border opacity-30 rotate-12" />
         <div className="container mx-auto px-6 py-12 md:px-10 relative z-10">

--- a/src/app/(protected)/(main)/downloads/loading.tsx
+++ b/src/app/(protected)/(main)/downloads/loading.tsx
@@ -1,7 +1,7 @@
 export default function DownloadsLoading() {
   const row = 'flex gap-4 p-4 border-[3px] border-border';
   return (
-    <div className="min-h-[calc(100vh-80px)] bg-background pb-32 animate-pulse">
+    <div className="min-h-[calc(100vh-80px)] pb-32 animate-pulse">
       <div className="container mx-auto px-6 py-12 md:px-10">
         <div className="h-14 w-56 bg-muted rounded mb-2" />
         <div className="h-5 w-36 bg-muted rounded mb-10" />

--- a/src/app/(protected)/(main)/home/loading.tsx
+++ b/src/app/(protected)/(main)/home/loading.tsx
@@ -1,6 +1,6 @@
 export default function HomeLoading() {
   return (
-    <main className="flex-grow flex flex-col items-center justify-center p-4 sm:p-8 h-[calc(100dvh-120px)] min-h-[600px] w-full bg-background animate-pulse">
+    <main className="flex-grow flex flex-col items-center justify-center p-4 sm:p-8 h-[calc(100dvh-120px)] min-h-[600px] w-full animate-pulse">
       <div className="h-16 md:h-24 w-80 bg-muted rounded mb-6" />
       <div className="h-12 w-64 bg-muted rounded mb-4" />
       <div className="h-5 w-48 bg-muted rounded" />

--- a/src/app/(protected)/(main)/layout.tsx
+++ b/src/app/(protected)/(main)/layout.tsx
@@ -2,21 +2,91 @@
 
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Suspense } from 'react';
+import {
+  createContext,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { LeftSidebar } from '@/components/layout/left-sidebar';
 import { Navbar } from '@/components/layout/navbar';
 import { OfflineState } from '@/components/layout/OfflineState';
+import { RightSidebar } from '@/components/layout/right-sidebar';
 import { GlobalTour } from '@/components/ui/global-tour';
 import { useNetworkStatus } from '@/hooks/use-network-status';
 import { useAuth } from '@/providers/auth-provider';
 import { ServerProvider } from '@/providers/server-provider';
+
+type SidebarContextType = {
+  leftOpen: boolean;
+  rightOpen: boolean;
+};
+
+const SidebarContext = createContext<SidebarContextType>({
+  leftOpen: false,
+  rightOpen: false,
+});
+
+export const useSidebar = () => useContext(SidebarContext);
+
+const LEFT_OPEN_ZONE = 50;
+const LEFT_CLOSE_ZONE = 340;
+const RIGHT_OPEN_ZONE = 50;
+const RIGHT_CLOSE_ZONE = 340;
 
 function MainLayoutInner({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
   const pathname = usePathname() || '';
   const { isOffline, mounted } = useNetworkStatus();
   const t = useTranslations('common');
+  const [leftOpen, setLeftOpen] = useState(false);
+  const [rightOpen, setRightOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  // Do not show the offline blocker inside player routes or offline vault
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const fromRight = rect.width - x;
+
+      // Left sidebar
+      if (x < LEFT_OPEN_ZONE) {
+        setLeftOpen(true);
+      } else if (x > LEFT_CLOSE_ZONE && leftOpen) {
+        setLeftOpen(false);
+      }
+
+      // Right sidebar
+      if (fromRight < RIGHT_OPEN_ZONE) {
+        setRightOpen(true);
+      } else if (fromRight > RIGHT_CLOSE_ZONE && rightOpen) {
+        setRightOpen(false);
+      }
+    },
+    [leftOpen, rightOpen],
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    setLeftOpen(false);
+    setRightOpen(false);
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.addEventListener('mousemove', handleMouseMove);
+    container.addEventListener('mouseleave', handleMouseLeave);
+    return () => {
+      container.removeEventListener('mousemove', handleMouseMove);
+      container.removeEventListener('mouseleave', handleMouseLeave);
+    };
+  }, [handleMouseMove, handleMouseLeave]);
+
   const bypassOfflineState =
     pathname.startsWith('/watch/') ||
     pathname.startsWith('/watch-party/') ||
@@ -26,23 +96,33 @@ function MainLayoutInner({ children }: { children: React.ReactNode }) {
   const showOfflineBlocker = mounted && isOffline && !bypassOfflineState;
 
   return (
-    <ServerProvider defaultServer={user?.preferredServer}>
-      <div className="min-h-[100dvh] w-full bg-background text-foreground font-body flex flex-col">
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:top-2 focus:left-2 focus:bg-neo-yellow focus:text-foreground focus:px-4 focus:py-2 focus:border-[3px] focus:border-border focus:font-headline focus:font-black focus:uppercase focus:text-sm focus:tracking-widest"
-        >
-          {t('skipToContent')}
-        </a>
-        <Suspense fallback={null}>
-          <GlobalTour />
-        </Suspense>
-        <Navbar />
-        <div id="main-content" className="flex-grow flex flex-col">
-          {showOfflineBlocker ? <OfflineState /> : children}
+    <SidebarContext.Provider value={{ leftOpen, rightOpen }}>
+      <ServerProvider defaultServer={user?.preferredServer}>
+        <div className="min-h-[100dvh] w-full bg-background text-foreground font-body flex flex-col">
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:top-2 focus:left-2 focus:bg-neo-yellow focus:text-foreground focus:px-4 focus:py-2 focus:border-[3px] focus:border-border focus:font-headline focus:font-black focus:uppercase focus:text-sm focus:tracking-widest"
+          >
+            {t('skipToContent')}
+          </a>
+          <Suspense fallback={null}>
+            <GlobalTour />
+          </Suspense>
+          <Navbar />
+          <div
+            ref={containerRef}
+            id="main-content"
+            className="flex-grow flex flex-row min-h-0 gap-2 p-2 h-[calc(100dvh-5rem)] overflow-hidden"
+          >
+            <LeftSidebar />
+            <div className="flex-grow flex flex-col overflow-y-auto overflow-x-hidden rounded-2xl bg-card min-w-0 transition-all duration-300 [&_.container]:!max-w-full">
+              {showOfflineBlocker ? <OfflineState /> : children}
+            </div>
+            <RightSidebar />
+          </div>
         </div>
-      </div>
-    </ServerProvider>
+      </ServerProvider>
+    </SidebarContext.Provider>
   );
 }
 

--- a/src/app/(protected)/(main)/library/page.tsx
+++ b/src/app/(protected)/(main)/library/page.tsx
@@ -1,0 +1,36 @@
+export default function LibraryPage() {
+  return (
+    <main className="min-h-full bg-background pb-32">
+      {/* Hero Header */}
+      <div className="mb-12 bg-neo-orange relative overflow-hidden rounded-2xl">
+        <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />
+        <div className="absolute top-10 left-1/4 w-24 h-24 bg-neo-red border-[4px] border-border opacity-30 rotate-12" />
+
+        <div className="container mx-auto px-6 py-12 md:px-10 relative z-10">
+          <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-8">
+            <div>
+              <h1 className="text-6xl md:text-8xl lg:text-9xl font-black tracking-tighter text-foreground font-headline uppercase leading-none mb-4">
+                MY
+                <br />
+                <span className="bg-background text-foreground px-4 inline-block border-[4px] border-border -rotate-1 ml-2 mt-2">
+                  LIBRARY
+                </span>
+              </h1>
+              <p className="font-headline font-bold uppercase tracking-widest text-foreground bg-background inline-block px-4 py-2 border-[3px] border-border">
+                All your content in one place
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="container mx-auto px-6 md:px-10">
+        <div className="flex flex-col items-center justify-center py-24">
+          <p className="text-sm text-foreground/30 font-headline uppercase tracking-widest">
+            Coming soon
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(protected)/(main)/library/page.tsx
+++ b/src/app/(protected)/(main)/library/page.tsx
@@ -1,6 +1,6 @@
 export default function LibraryPage() {
   return (
-    <main className="min-h-full bg-background pb-32">
+    <main className="min-h-full pb-32">
       {/* Hero Header */}
       <div className="mb-12 bg-neo-orange relative overflow-hidden rounded-2xl">
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />

--- a/src/app/(protected)/(main)/live/LiveClient.tsx
+++ b/src/app/(protected)/(main)/live/LiveClient.tsx
@@ -29,8 +29,18 @@ function LiveContent() {
   const format = useFormatter();
 
   const SERVERS = [
-    { id: 'server1' as const, label: t('server1'), desc: t('server1Desc') },
-    { id: 'server2' as const, label: t('server2'), desc: t('server2Desc') },
+    {
+      id: 'server1' as const,
+      label: t('server1'),
+      short: 'S1',
+      desc: t('server1Desc'),
+    },
+    {
+      id: 'server2' as const,
+      label: t('server2'),
+      short: 'S2',
+      desc: t('server2Desc'),
+    },
   ];
 
   const SERVER_1_SPORTS = [{ id: 'all_channels', label: t('allChannels') }];
@@ -83,15 +93,15 @@ function LiveContent() {
   );
 
   return (
-    <div className="min-h-[calc(100vh-80px)] bg-background pb-32 overflow-x-hidden">
+    <div className="min-h-full bg-background pb-32 overflow-x-hidden">
       {/* Hero Header */}
-      <div className="border-b-[4px] border-border mb-12 bg-neo-yellow relative z-40">
+      <div className="mb-12 bg-neo-yellow relative z-40 rounded-2xl overflow-hidden">
         {/* Abstract background shapes */}
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-10" />
         <div className="absolute top-10 left-1/4 w-24 h-24 bg-neo-red border-[4px] border-border opacity-20 rotate-12" />
 
         <div className="container mx-auto px-6 py-12 md:px-10 relative z-10">
-          <div className="flex flex-col xl:flex-row xl:items-end justify-between gap-8">
+          <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-8">
             <div className="flex-shrink-0">
               <h1 className="text-6xl md:text-8xl lg:text-9xl font-black tracking-tighter text-foreground font-headline uppercase leading-none mb-4">
                 {t('heroTitle')}
@@ -108,9 +118,9 @@ function LiveContent() {
               </div>
             </div>
 
-            <div className="flex flex-col md:flex-row items-start md:items-end gap-6 w-full max-w-full xl:max-w-4xl relative">
+            <div className="flex flex-col md:flex-row items-start md:items-end gap-6 w-full min-w-0 relative">
               {/* Server Selector Dropdown */}
-              <div className="relative w-full md:w-auto shrink-0 z-50">
+              <div className="relative w-full md:w-auto shrink-0 md:shrink min-w-0 z-50">
                 <p className="font-headline font-black text-xs uppercase tracking-[0.2em] text-foreground/40 mb-2 ml-1">
                   1. {t('regionProvider')}
                 </p>
@@ -123,22 +133,27 @@ function LiveContent() {
                   aria-haspopup="menu"
                   aria-expanded={isServerMenuOpen}
                   aria-controls="live-server-menu"
-                  className={`flex items-center justify-between gap-4 px-5 md:px-6 py-3 md:py-4 font-headline font-black text-base md:text-xl uppercase tracking-widest transition-colors duration-200 border-[3px] border-border whitespace-nowrap min-w-[220px] md:min-w-[260px] hover:bg-muted hover:text-foreground cursor-pointer rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neo-blue focus-visible:ring-offset-2 ${
+                  className={`flex items-center justify-between gap-4 px-5 md:px-6 py-3 md:py-4 font-headline font-black text-base md:text-xl uppercase tracking-widest transition-colors duration-200 border-[3px] border-border w-full min-w-0 hover:bg-muted hover:text-foreground cursor-pointer rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neo-blue focus-visible:ring-offset-2 ${
                     isServerMenuOpen || activeServer
                       ? 'bg-muted text-foreground'
                       : 'bg-background'
                   }`}
                 >
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
                     {activeServer === 'server1' ? (
-                      <Radio className="w-6 h-6" />
+                      <Radio className="w-6 h-6 shrink-0" />
                     ) : (
-                      <Globe2 className="w-6 h-6" />
+                      <Globe2 className="w-6 h-6 shrink-0" />
                     )}
-                    {SERVERS.find((s) => s.id === activeServer)?.label}
+                    <span className="truncate hidden lg:inline">
+                      {SERVERS.find((s) => s.id === activeServer)?.label}
+                    </span>
+                    <span className="truncate lg:hidden">
+                      {SERVERS.find((s) => s.id === activeServer)?.short}
+                    </span>
                   </div>
                   <ChevronDown
-                    className={`w-6 h-6 transition-transform duration-300 ${
+                    className={`w-6 h-6 shrink-0 transition-transform duration-300 ${
                       isServerMenuOpen ? 'rotate-180' : ''
                     }`}
                   />
@@ -186,7 +201,7 @@ function LiveContent() {
               </div>
 
               {/* Sport Selector Dropdown */}
-              <div className="relative w-full md:w-auto flex-grow z-40">
+              <div className="relative w-full md:w-auto flex-grow min-w-0 z-40">
                 <p className="font-headline font-black text-xs uppercase tracking-[0.2em] text-foreground/40 mb-2 ml-1">
                   2. {t('selectCoverage')}
                 </p>
@@ -199,14 +214,14 @@ function LiveContent() {
                   aria-haspopup="menu"
                   aria-expanded={isSportMenuOpen}
                   aria-controls="live-sport-menu"
-                  className="flex items-center justify-between gap-4 px-5 md:px-6 py-3 md:py-4 font-headline font-black text-base md:text-xl uppercase tracking-widest transition-colors duration-200 border-[3px] border-border whitespace-nowrap w-full md:min-w-[300px] bg-background text-foreground hover:bg-muted cursor-pointer rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neo-blue focus-visible:ring-offset-2"
+                  className="flex items-center justify-between gap-4 px-5 md:px-6 py-3 md:py-4 font-headline font-black text-base md:text-xl uppercase tracking-widest transition-colors duration-200 border-[3px] border-border w-full bg-background text-foreground hover:bg-muted cursor-pointer rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neo-blue focus-visible:ring-offset-2 min-w-0"
                 >
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
                     <span className="w-3 h-3 bg-neo-red border-[2px] border-border rounded-full animate-pulse shrink-0" />
-                    {activeSport?.label}
+                    <span className="truncate">{activeSport?.label}</span>
                   </div>
                   <ChevronDown
-                    className={`w-6 h-6 transition-transform duration-300 ${
+                    className={`w-6 h-6 shrink-0 transition-transform duration-300 ${
                       isSportMenuOpen ? 'rotate-180' : ''
                     }`}
                   />

--- a/src/app/(protected)/(main)/live/LiveClient.tsx
+++ b/src/app/(protected)/(main)/live/LiveClient.tsx
@@ -93,7 +93,7 @@ function LiveContent() {
   );
 
   return (
-    <div className="min-h-full bg-background pb-32 overflow-x-hidden">
+    <div className="min-h-full pb-32 overflow-x-hidden">
       {/* Hero Header */}
       <div className="mb-12 bg-neo-yellow relative z-40 rounded-2xl overflow-hidden">
         {/* Abstract background shapes */}

--- a/src/app/(protected)/(main)/live/loading.tsx
+++ b/src/app/(protected)/(main)/live/loading.tsx
@@ -1,7 +1,7 @@
 export default function LiveLoading() {
   const row = 'flex items-center gap-4 p-4 border-[3px] border-border';
   return (
-    <div className="min-h-[calc(100vh-80px)] bg-background pb-32 animate-pulse">
+    <div className="min-h-[calc(100vh-80px)] pb-32 animate-pulse">
       <div className="mb-12 bg-neo-yellow rounded-2xl">
         <div className="container mx-auto px-6 py-12 md:px-10">
           <div className="h-20 md:h-32 w-64 bg-foreground/10 rounded mb-4" />

--- a/src/app/(protected)/(main)/live/loading.tsx
+++ b/src/app/(protected)/(main)/live/loading.tsx
@@ -2,7 +2,7 @@ export default function LiveLoading() {
   const row = 'flex items-center gap-4 p-4 border-[3px] border-border';
   return (
     <div className="min-h-[calc(100vh-80px)] bg-background pb-32 animate-pulse">
-      <div className="border-b-[4px] border-border mb-12 bg-neo-yellow">
+      <div className="mb-12 bg-neo-yellow rounded-2xl">
         <div className="container mx-auto px-6 py-12 md:px-10">
           <div className="h-20 md:h-32 w-64 bg-foreground/10 rounded mb-4" />
           <div className="h-6 w-48 bg-foreground/10 rounded" />

--- a/src/app/(protected)/(main)/watchlist/loading.tsx
+++ b/src/app/(protected)/(main)/watchlist/loading.tsx
@@ -1,6 +1,6 @@
 export default function WatchlistLoading() {
   return (
-    <div className="min-h-[calc(100vh-80px)] bg-background pb-32 flex flex-col">
+    <div className="min-h-[calc(100vh-80px)] pb-32 flex flex-col">
       {/* Hero - red bg, same as real page */}
       <div className="mb-12 bg-neo-red relative overflow-hidden shrink-0 rounded-2xl">
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />

--- a/src/app/(protected)/(main)/watchlist/loading.tsx
+++ b/src/app/(protected)/(main)/watchlist/loading.tsx
@@ -2,7 +2,7 @@ export default function WatchlistLoading() {
   return (
     <div className="min-h-[calc(100vh-80px)] bg-background pb-32 flex flex-col">
       {/* Hero - red bg, same as real page */}
-      <div className="border-b-[4px] border-border mb-12 bg-neo-red relative overflow-hidden shrink-0">
+      <div className="mb-12 bg-neo-red relative overflow-hidden shrink-0 rounded-2xl">
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />
         <div className="absolute top-10 left-1/4 w-24 h-24 bg-neo-yellow border-[4px] border-border opacity-30 rotate-12" />
         <div className="container mx-auto px-6 py-12 md:px-10 relative z-10">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,9 @@
   --color-neo-yellow: var(--neo-yellow);
   --color-neo-red: var(--neo-red);
   --color-neo-blue: var(--neo-blue);
+  --color-neo-green: var(--neo-green);
+  --color-neo-orange: var(--neo-orange);
+  --color-neo-cyan: var(--neo-cyan);
   --color-neo-muted: var(--neo-muted);
   --color-neo-text: var(--neo-text);
 
@@ -104,6 +107,9 @@
     --neo-yellow: #ffcc00;
     --neo-red: #e63b2e;
     --neo-blue: #0055ff;
+    --neo-green: #10b981;
+    --neo-orange: #f97316;
+    --neo-cyan: #06b6d4;
     --neo-muted: #d4d4d8;
     --neo-text: #1a1a1a;
 
@@ -307,6 +313,9 @@
     --neo-yellow: #a855f7; /* Changed yellow to purple in dark mode! */
     --neo-red: #fb7185;
     --neo-blue: #38bdf8;
+    --neo-green: #34d399;
+    --neo-orange: #c084fc;
+    --neo-cyan: #facc15;
     --neo-muted: #3f3f46;
     --neo-text: #f4f4f5;
 

--- a/src/components/layout/left-sidebar.tsx
+++ b/src/components/layout/left-sidebar.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import {
+  Bot,
+  History,
+  Home,
+  Library,
+  Monitor,
+  Plus,
+  Radio,
+  Sparkles,
+} from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
+import { useSidebar } from '@/app/(protected)/(main)/layout';
+import { useDesktopApp } from '@/hooks/use-desktop-app';
+
+function useOSName() {
+  return useMemo(() => {
+    if (typeof navigator === 'undefined') return null;
+    const ua = navigator.userAgent;
+    if (/Mac/i.test(ua)) return 'macOS';
+    if (/Win/i.test(ua)) return 'Windows';
+    if (/Linux/i.test(ua)) return 'Linux';
+    return null;
+  }, []);
+}
+
+export function LeftSidebar() {
+  const { leftOpen: open } = useSidebar();
+  const pathname = usePathname();
+  const { isDesktopApp, isMounted } = useDesktopApp();
+  const t = useTranslations('common.nav');
+  const td = useTranslations('common.desktopApp');
+  const tw = useTranslations('common.whatsNew');
+  const osName = useOSName();
+
+  const isActive = (href: string) => pathname?.startsWith(href);
+
+  const links = [
+    { href: '/home', label: t('home'), icon: Home },
+    { href: '/continue-watching', label: t('continue'), icon: History },
+    { href: '/live', label: t('live'), icon: Radio },
+    { href: '/watchlist', label: t('watchlist'), icon: Plus },
+    { href: '/library', label: 'Library', icon: Library },
+    { href: '/ask-ai', label: 'Ask AI', icon: Bot },
+    ...(isMounted && isDesktopApp
+      ? [{ href: '/changelog', label: tw('title'), icon: Sparkles }]
+      : []),
+  ];
+
+  const showDownloadApp = isMounted && !isDesktopApp && osName;
+
+  return (
+    <aside
+      className={`shrink-0 h-full bg-card flex flex-col overflow-hidden transition-all duration-300 ease-in-out ${
+        open ? 'w-80 rounded-2xl' : 'w-11 hover:w-14 rounded-r-2xl -ml-2'
+      }`}
+    >
+      {open ? (
+        <nav className="flex-1 flex flex-col gap-1.5 py-3 px-3 overflow-hidden">
+          {links.map(({ href, label, icon: Icon }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`flex items-center gap-3 px-4 py-3 rounded-xl font-headline font-bold uppercase text-sm tracking-widest transition-colors whitespace-nowrap ${
+                isActive(href)
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-foreground/70 hover:bg-black/5 hover:text-foreground dark:hover:bg-white/5'
+              }`}
+            >
+              <Icon className="w-5 h-5 stroke-[2.5px] shrink-0" />
+              {label}
+            </Link>
+          ))}
+          {showDownloadApp && (
+            <Link
+              href="/changelog"
+              className={`flex items-center gap-3 px-4 py-3 rounded-xl font-headline font-bold uppercase text-sm tracking-widest transition-colors whitespace-nowrap mt-auto ${
+                isActive('/changelog')
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-foreground/70 hover:bg-black/5 hover:text-foreground dark:hover:bg-white/5'
+              }`}
+            >
+              <Sparkles className="w-5 h-5 stroke-[2.5px] shrink-0" />
+              {tw('title')}
+            </Link>
+          )}
+          {showDownloadApp && (
+            <a
+              href="https://github.com/rudra-sah00/watch-rudra/releases/latest"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 px-4 py-3 rounded-xl font-headline font-bold uppercase text-sm tracking-widest transition-colors whitespace-nowrap text-foreground/70 hover:bg-black/5 hover:text-foreground dark:hover:bg-white/5"
+            >
+              <Monitor className="w-5 h-5 stroke-[2.5px] shrink-0" />
+              {td('downloadFor', { os: osName })}
+            </a>
+          )}
+        </nav>
+      ) : (
+        <div className="flex-1 flex items-center justify-center">
+          <span className="material-symbols-outlined text-xl text-foreground/60">
+            menu
+          </span>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -1,20 +1,16 @@
 'use client';
 
-import { DownloadCloud, History, Plus, Radio, User } from 'lucide-react';
+import { User } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useDesktopApp } from '@/hooks/use-desktop-app';
 import { useAuth } from '@/providers/auth-provider';
 
 export function Navbar() {
   const { user } = useAuth();
-  const pathname = usePathname();
   const { isDesktopApp, isMounted, isMacOS, isWindows } = useDesktopApp();
   const t = useTranslations('common.nav');
-
-  const isActive = (href: string) => pathname?.startsWith(href);
 
   return (
     <nav
@@ -31,7 +27,6 @@ export function Navbar() {
             className="flex items-center gap-2 py-4 px-2 [-webkit-app-region:no-drag]"
             title={t('home')}
           >
-            {/* Mobile: Play Icon */}
             <div className="md:hidden w-10 h-10 border border-border bg-neo-yellow flex items-center justify-center rounded-md hover:bg-neo-yellow/80 transition-colors shrink-0">
               <img
                 src="/play.ico"
@@ -41,46 +36,9 @@ export function Navbar() {
                 className="w-6 h-6 object-contain"
               />
             </div>
-            {/* Desktop: Text Logo */}
             <span className="hidden md:block text-2xl md:text-3xl font-black italic tracking-tighter text-foreground font-headline uppercase whitespace-nowrap">
               WATCH RUDRA
             </span>
-          </Link>
-        </div>
-
-        {/* Middle: Global Navigation - Icons only on mobile, text only on desktop */}
-        <div className="flex items-center justify-center gap-6 sm:gap-8 font-headline uppercase font-bold tracking-tighter text-sm md:text-base md:flex-1">
-          <Link
-            href="/continue-watching"
-            className={`py-4 px-2 [-webkit-app-region:no-drag] hover:text-foreground transition-colors flex items-center gap-2 group ${isActive('/continue-watching') ? 'text-foreground' : 'text-foreground/70'}`}
-            title={t('continueWatching')}
-          >
-            <History className="md:hidden w-5 h-5 sm:w-6 sm:h-6 stroke-[3px] group-hover:scale-110" />
-            <span className="hidden md:inline">{t('continue')}</span>
-          </Link>
-          <Link
-            href="/live"
-            className={`py-4 px-2 [-webkit-app-region:no-drag] hover:text-foreground transition-colors flex items-center gap-2 group ${isActive('/live') ? 'text-foreground' : 'text-foreground/70'}`}
-            title={t('liveMatches')}
-          >
-            <Radio className="md:hidden w-5 h-5 sm:w-6 sm:h-6 stroke-[3px] group-hover:scale-110" />
-            <span className="hidden md:inline">{t('live')}</span>
-          </Link>
-          <Link
-            href="/watchlist"
-            className={`py-4 px-2 [-webkit-app-region:no-drag] hover:text-foreground transition-colors flex items-center gap-2 group ${isActive('/watchlist') ? 'text-foreground' : 'text-foreground/70'}`}
-            title={t('watchlist')}
-          >
-            <Plus className="md:hidden w-5 h-5 sm:w-6 sm:h-6 stroke-[3px] group-hover:scale-110" />
-            <span className="hidden md:inline">{t('watchlist')}</span>
-          </Link>
-          <Link
-            href="/downloads"
-            className={`py-4 px-2 [-webkit-app-region:no-drag] hover:text-foreground transition-colors flex items-center gap-2 group ${isActive('/downloads') ? 'text-foreground' : 'text-foreground/70'} ${isMounted && isDesktopApp ? '' : 'hidden'}`}
-            title={t('offlineDownloads')}
-          >
-            <DownloadCloud className="md:hidden w-5 h-5 sm:w-6 sm:h-6 stroke-[3px] group-hover:scale-110" />
-            <span className="hidden md:inline">{t('downloads')}</span>
           </Link>
         </div>
 

--- a/src/components/layout/right-sidebar.tsx
+++ b/src/components/layout/right-sidebar.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useSidebar } from '@/app/(protected)/(main)/layout';
+
+export function RightSidebar() {
+  const { rightOpen: open } = useSidebar();
+
+  return (
+    <aside
+      className={`shrink-0 h-full bg-card flex flex-col overflow-hidden transition-all duration-300 ease-in-out ${
+        open ? 'w-80 rounded-2xl' : 'w-11 hover:w-14 rounded-l-2xl -mr-2'
+      }`}
+    >
+      {open ? (
+        <>
+          <div className="flex items-center px-4 pt-4 pb-3 border-b border-border">
+            <span className="text-sm font-black uppercase tracking-widest font-headline text-foreground">
+              Friends
+            </span>
+          </div>
+          <div className="flex-1 flex items-center justify-center p-6">
+            <p className="text-sm text-foreground/30 font-headline uppercase tracking-widest text-center">
+              Coming soon
+            </p>
+          </div>
+        </>
+      ) : (
+        <div className="flex-1 flex items-center justify-center">
+          <span className="material-symbols-outlined text-xl text-foreground/60">
+            group
+          </span>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/features/downloads/components/OfflineLibrary.tsx
+++ b/src/features/downloads/components/OfflineLibrary.tsx
@@ -97,7 +97,7 @@ export function OfflineLibrary() {
   return (
     <main className="min-h-[calc(100vh-80px)] bg-background pb-32 animate-in fade-in">
       {/* Hero Header */}
-      <div className="border-b-[4px] border-border mb-12 bg-neo-yellow relative overflow-hidden">
+      <div className="mb-12 bg-neo-cyan relative overflow-hidden rounded-2xl">
         {/* Abstract background shapes */}
         <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />
         <div className="absolute top-10 left-1/4 w-24 h-24 bg-neo-blue border-[4px] border-border opacity-30 rotate-12" />

--- a/src/features/profile/components/app-preferences.tsx
+++ b/src/features/profile/components/app-preferences.tsx
@@ -118,7 +118,7 @@ export function AppPreferences() {
             <DialogTrigger asChild>
               <button
                 type="button"
-                className="flex items-center gap-3 px-5 py-3 border rounded-lg transition-all shadow-sm cursor-pointer bg-card text-card-foreground border-border hover:border-primary/50 hover:shadow-md"
+                className="flex items-center gap-3 px-5 py-3 bg-transparent text-foreground border border-border hover:bg-primary hover:text-primary-foreground rounded-md font-headline font-medium tracking-normal transition-[background-color,color,border-color,opacity,transform] cursor-pointer"
               >
                 {theme === 'light' ? (
                   <Sun className="w-4 h-4" />
@@ -201,7 +201,7 @@ export function AppPreferences() {
             trigger={
               <button
                 type="button"
-                className="flex items-center gap-3 px-5 py-3 border rounded-lg transition-all shadow-sm cursor-pointer bg-card text-card-foreground border-border hover:border-primary/50 hover:shadow-md"
+                className="flex items-center gap-3 px-5 py-3 bg-transparent text-foreground border border-border hover:bg-primary hover:text-primary-foreground rounded-md font-headline font-medium tracking-normal transition-[background-color,color,border-color,opacity,transform] cursor-pointer"
               >
                 <Globe className="w-4 h-4" />
                 {locale}
@@ -263,7 +263,7 @@ export function AppPreferences() {
                 <DialogTrigger asChild>
                   <button
                     type="button"
-                    className="flex items-center gap-3 px-5 py-3 border rounded-lg transition-all shadow-sm cursor-pointer bg-card text-card-foreground border-border hover:border-primary/50 hover:shadow-md"
+                    className="flex items-center gap-3 px-5 py-3 bg-transparent text-foreground border border-border hover:bg-primary hover:text-primary-foreground rounded-md font-headline font-medium tracking-normal transition-[background-color,color,border-color,opacity,transform] cursor-pointer"
                   >
                     <Activity className="w-4 h-4" />
                     {concurrentDownloads}
@@ -342,7 +342,7 @@ export function AppPreferences() {
                 <DialogTrigger asChild>
                   <button
                     type="button"
-                    className="flex items-center gap-3 px-5 py-3 border rounded-lg transition-all shadow-sm cursor-pointer bg-card text-card-foreground border-border hover:border-primary/50 hover:shadow-md"
+                    className="flex items-center gap-3 px-5 py-3 bg-transparent text-foreground border border-border hover:bg-primary hover:text-primary-foreground rounded-md font-headline font-medium tracking-normal transition-[background-color,color,border-color,opacity,transform] cursor-pointer"
                   >
                     <Zap className="w-4 h-4" />
                     {downloadSpeedLimit === 0

--- a/src/features/profile/components/profile-overview.tsx
+++ b/src/features/profile/components/profile-overview.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Eye, EyeOff, Loader2 } from 'lucide-react';
-import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { CreatorFooter } from '@/components/ui/creator-footer';
@@ -168,27 +167,6 @@ export function ProfileOverview() {
           createdAt={userCreatedAtDate}
           isLoading={loadingActivity}
         />
-      </section>
-
-      {/* App Updates / What's New */}
-      <section className="bg-card text-card-foreground border border-border rounded-xl shadow-sm p-8">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
-          <div className="flex flex-col gap-2">
-            <h2 className="text-3xl font-black font-headline uppercase tracking-tighter">
-              {t('releaseNotes.title')}
-            </h2>
-            <p className="text-muted-foreground font-body text-sm max-w-sm">
-              {t('releaseNotes.description')}
-            </p>
-          </div>
-
-          <Link
-            href="/whats-new"
-            className="flex-shrink-0 py-3 px-8 bg-primary text-primary-foreground font-semibold font-headline tracking-widest rounded-lg hover:bg-primary/90 transition-colors shadow-sm text-sm uppercase"
-          >
-            {t('releaseNotes.viewButton')}
-          </Link>
-        </div>
       </section>
 
       <CreatorFooter isCompact={false} />

--- a/src/features/search/components/HomeClient.tsx
+++ b/src/features/search/components/HomeClient.tsx
@@ -17,7 +17,7 @@ export function HomeClient() {
   } = useSearchInput();
 
   return (
-    <main className="flex-grow flex flex-col items-center justify-center p-4 sm:p-8 relative h-[calc(100dvh-120px)] min-h-[600px] w-full overflow-hidden bg-background">
+    <main className="flex-grow flex flex-col items-center justify-center p-4 sm:p-8 relative h-[calc(100dvh-120px)] min-h-[600px] w-full overflow-hidden">
       {/* Abstract Bauhaus Background Elements */}
       <div className="absolute top-20 left-10 w-32 h-32 border-[3px] border-border opacity-20 -z-10 rotate-12"></div>
       <div className="absolute bottom-20 right-10 w-48 h-48 bg-neo-red opacity-10 -z-10 rounded-full"></div>

--- a/src/features/search/components/SearchClient.tsx
+++ b/src/features/search/components/SearchClient.tsx
@@ -101,7 +101,10 @@ export function SearchClient({
           </div>
 
           <div className="space-y-6">
-            {serverError && hasSearched && results.length === 0 ? (
+            {serverError &&
+            !isTransitioning &&
+            hasSearched &&
+            results.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-20 bg-neo-surface border-[4px] border-border text-center">
                 <span className="text-5xl mb-4">⚠️</span>
                 <p className="font-headline font-black uppercase tracking-widest text-foreground mb-2">

--- a/src/features/search/hooks/use-home-client.ts
+++ b/src/features/search/hooks/use-home-client.ts
@@ -13,11 +13,13 @@ import { useServer } from '@/providers/server-provider';
 interface UseHomeClientOptions {
   initialResults: SearchResult[];
   initialQuery: string;
+  initialServer?: string;
 }
 
 export function useHomeClient({
   initialResults,
   initialQuery,
+  initialServer,
 }: UseHomeClientOptions) {
   const t = useTranslations('common.toasts');
   const searchParams = useSearchParams();
@@ -55,7 +57,11 @@ export function useHomeClient({
       startTransition(() => setResults([]));
       return;
     }
-    if (query === initialQuery && initialResults.length > 0) {
+    if (
+      query === initialQuery &&
+      initialResults.length > 0 &&
+      activeServer === (initialServer || 's1')
+    ) {
       return;
     }
 
@@ -83,7 +89,7 @@ export function useHomeClient({
 
     fetchResults();
     return () => controller.abort();
-  }, [query, initialQuery, initialResults, activeServer, t]);
+  }, [query, initialQuery, initialResults, activeServer, initialServer, t]);
 
   useEffect(() => {
     setIsContinueWatchingLoading(true);

--- a/src/features/watchlist/components/WatchlistClient.tsx
+++ b/src/features/watchlist/components/WatchlistClient.tsx
@@ -32,7 +32,7 @@ export function WatchlistClient() {
 
   return (
     <>
-      <div className="min-h-full bg-background pb-32 animate-in fade-in flex flex-col">
+      <div className="min-h-full pb-32 animate-in fade-in flex flex-col">
         {/* Hero Header */}
         <div className="mb-12 bg-neo-red relative overflow-hidden shrink-0 rounded-2xl">
           {/* Abstract background shapes */}

--- a/src/features/watchlist/components/WatchlistClient.tsx
+++ b/src/features/watchlist/components/WatchlistClient.tsx
@@ -32,20 +32,20 @@ export function WatchlistClient() {
 
   return (
     <>
-      <div className="min-h-[calc(100vh-80px)] bg-background pb-32 animate-in fade-in flex flex-col">
+      <div className="min-h-full bg-background pb-32 animate-in fade-in flex flex-col">
         {/* Hero Header */}
-        <div className="border-b-[4px] border-border mb-12 bg-neo-red relative overflow-hidden shrink-0">
+        <div className="mb-12 bg-neo-red relative overflow-hidden shrink-0 rounded-2xl">
           {/* Abstract background shapes */}
           <div className="absolute -top-10 -right-10 w-64 h-64 border-[4px] border-border rounded-full opacity-20" />
           <div className="absolute top-10 left-1/4 w-24 h-24 bg-neo-yellow border-[4px] border-border opacity-30 rotate-12" />
 
           <div className="container mx-auto px-6 py-12 md:px-10 relative z-10">
-            <div className="flex flex-col xl:flex-row xl:items-end justify-between gap-8">
+            <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-8">
               <div>
                 <h1 className="text-6xl md:text-8xl lg:text-9xl font-black tracking-tighter text-white font-headline uppercase leading-none mb-4 min-w-0">
                   {t('pageTitle')}
                   <br />
-                  <span className="bg-neo-yellow text-foreground px-4 inline-block border-[4px] border-border  -rotate-1 ml-2 mt-2">
+                  <span className="bg-background text-foreground px-4 inline-block border-[4px] border-border  -rotate-1 ml-2 mt-2">
                     {t('watchlist')}
                   </span>
                 </h1>

--- a/src/i18n/messages/ar/common.json
+++ b/src/i18n/messages/ar/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "التطبيق غير مثبت",
     "notInstalledDesc": "تعذر فتح تطبيق Watch Rudra. هل هو مثبت؟",
-    "downloadApp": "تحميل التطبيق"
+    "downloadApp": "تحميل التطبيق",
+    "downloadFor": "تحميل لـ {os}"
   },
   "whatsNew": {
     "backToHome": "العودة للرئيسية",

--- a/src/i18n/messages/de/common.json
+++ b/src/i18n/messages/de/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "App nicht installiert",
     "notInstalledDesc": "Die Watch Rudra Desktop-App konnte nicht geöffnet werden. Ist sie installiert?",
-    "downloadApp": "App herunterladen"
+    "downloadApp": "App herunterladen",
+    "downloadFor": "Für {os} herunterladen"
   },
   "whatsNew": {
     "backToHome": "Zurück zur Startseite",

--- a/src/i18n/messages/en/common.json
+++ b/src/i18n/messages/en/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "App not installed",
     "notInstalledDesc": "We could not open the Watch Rudra Desktop app. Is it installed?",
-    "downloadApp": "Download App"
+    "downloadApp": "Download App",
+    "downloadFor": "Download for {os}"
   },
   "whatsNew": {
     "backToHome": "Back to Home",

--- a/src/i18n/messages/es/common.json
+++ b/src/i18n/messages/es/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "App no instalada",
     "notInstalledDesc": "No pudimos abrir la app de escritorio Watch Rudra. ¿Está instalada?",
-    "downloadApp": "Descargar App"
+    "downloadApp": "Descargar App",
+    "downloadFor": "Descargar para {os}"
   },
   "whatsNew": {
     "backToHome": "Volver al Inicio",

--- a/src/i18n/messages/fr/common.json
+++ b/src/i18n/messages/fr/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "App non installée",
     "notInstalledDesc": "Impossible d'ouvrir l'app Watch Rudra. Est-elle installée ?",
-    "downloadApp": "Télécharger l'App"
+    "downloadApp": "Télécharger l'App",
+    "downloadFor": "Télécharger pour {os}"
   },
   "whatsNew": {
     "backToHome": "Retour à l'Accueil",

--- a/src/i18n/messages/hi/common.json
+++ b/src/i18n/messages/hi/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "ऐप इंस्टॉल नहीं है",
     "notInstalledDesc": "हम Watch Rudra डेस्कटॉप ऐप नहीं खोल सके। क्या यह इंस्टॉल है?",
-    "downloadApp": "ऐप डाउनलोड करें"
+    "downloadApp": "ऐप डाउनलोड करें",
+    "downloadFor": "{os} के लिए डाउनलोड करें"
   },
   "whatsNew": {
     "backToHome": "होम पर वापस जाएँ",

--- a/src/i18n/messages/it/common.json
+++ b/src/i18n/messages/it/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "App non installata",
     "notInstalledDesc": "Impossibile aprire l'app Watch Rudra. È installata?",
-    "downloadApp": "Scarica App"
+    "downloadApp": "Scarica App",
+    "downloadFor": "Scarica per {os}"
   },
   "whatsNew": {
     "backToHome": "Torna alla Home",

--- a/src/i18n/messages/ja/common.json
+++ b/src/i18n/messages/ja/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "アプリ未インストール",
     "notInstalledDesc": "Watch Rudraデスクトップアプリを開けませんでした。インストールされていますか？",
-    "downloadApp": "アプリをダウンロード"
+    "downloadApp": "アプリをダウンロード",
+    "downloadFor": "{os}用ダウンロード"
   },
   "whatsNew": {
     "backToHome": "ホームに戻る",

--- a/src/i18n/messages/ko/common.json
+++ b/src/i18n/messages/ko/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "앱 미설치",
     "notInstalledDesc": "Watch Rudra 데스크톱 앱을 열 수 없습니다. 설치되어 있나요?",
-    "downloadApp": "앱 다운로드"
+    "downloadApp": "앱 다운로드",
+    "downloadFor": "{os}용 다운로드"
   },
   "whatsNew": {
     "backToHome": "홈으로 돌아가기",

--- a/src/i18n/messages/pt/common.json
+++ b/src/i18n/messages/pt/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "App não instalado",
     "notInstalledDesc": "Não foi possível abrir o app Watch Rudra. Está instalado?",
-    "downloadApp": "Baixar App"
+    "downloadApp": "Baixar App",
+    "downloadFor": "Baixar para {os}"
   },
   "whatsNew": {
     "backToHome": "Voltar ao Início",

--- a/src/i18n/messages/ru/common.json
+++ b/src/i18n/messages/ru/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "Приложение не установлено",
     "notInstalledDesc": "Не удалось открыть приложение Watch Rudra. Оно установлено?",
-    "downloadApp": "Скачать Приложение"
+    "downloadApp": "Скачать Приложение",
+    "downloadFor": "Скачать для {os}"
   },
   "whatsNew": {
     "backToHome": "Вернуться на Главную",

--- a/src/i18n/messages/th/common.json
+++ b/src/i18n/messages/th/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "ยังไม่ได้ติดตั้งแอป",
     "notInstalledDesc": "ไม่สามารถเปิดแอป Watch Rudra ได้ ติดตั้งแล้วหรือยัง?",
-    "downloadApp": "ดาวน์โหลดแอป"
+    "downloadApp": "ดาวน์โหลดแอป",
+    "downloadFor": "ดาวน์โหลดสำหรับ {os}"
   },
   "whatsNew": {
     "backToHome": "กลับหน้าแรก",

--- a/src/i18n/messages/tr/common.json
+++ b/src/i18n/messages/tr/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "Uygulama yüklü değil",
     "notInstalledDesc": "Watch Rudra masaüstü uygulaması açılamadı. Yüklü mü?",
-    "downloadApp": "Uygulamayı İndir"
+    "downloadApp": "Uygulamayı İndir",
+    "downloadFor": "{os} için İndir"
   },
   "whatsNew": {
     "backToHome": "Ana Sayfaya Dön",

--- a/src/i18n/messages/zh/common.json
+++ b/src/i18n/messages/zh/common.json
@@ -174,7 +174,8 @@
   "desktopApp": {
     "notInstalled": "应用未安装",
     "notInstalledDesc": "无法打开Watch Rudra桌面应用。是否已安装？",
-    "downloadApp": "下载应用"
+    "downloadApp": "下载应用",
+    "downloadFor": "下载 {os} 版"
   },
   "whatsNew": {
     "backToHome": "返回首页",


### PR DESCRIPTION
## Summary

### New: Sidebar Navigation & Layout Redesign
- Add left sidebar with hover-to-open navigation (Home, Continue, Live, Watchlist, Library, Ask AI, What's New, Download for OS)
- Add right sidebar with friends panel placeholder (coming soon)
- Sidebars use mouse position tracking for smooth open/close without flickering
- Move nav links from navbar to left sidebar, keep profile in navbar
- Add `/library`, `/ask-ai`, `/changelog` routes with hero sections
- Add neo-green, neo-orange, neo-cyan theme colors with distinct light/dark variants
- Unique hero colors per route: live(yellow), watchlist(red), continue(blue), library(orange), downloads(cyan), changelog(green)
- Remove 3D border from all hero sections, add rounded-2xl corners
- Update app preference buttons to match neo-outline style
- Remove What's New section from profile (moved to sidebar)

### Fix: Search Error Flash on Server 2 & 3
- Fix "search failed" error flashing before results when using server 2 or 3
- SSR always fetched from default server (s1), causing a serverError state to flash before the client-side re-fetch completed
- Make `useHomeClient` early-return server-aware so it properly re-fetches for the active server
- Hide `serverError` UI while a client-side transition is in progress

### Cleanup
- Remove redundant `bg-background` class from 11 page/loading components (inherited from parent layout)
- Add `downloadFor` i18n key with `{os}` placeholder to all 14 languages
- Fix live page dropdowns to be responsive with sidebar (truncate, flexible widths)

## Verified
- Biome: 405 files checked, 0 errors
- Tests: 105 test files, 1776 tests passing
- TypeScript: `tsc --noEmit` clean
- i18n: consistent across all 14 languages

## Changed Files
36 files changed, 470 insertions, 140 deletions