### PR TITLE
feat: landing page, splash screen, onboarding tour, legal pages & UI …

### DIFF
--- a/electron/modules/splash.js
+++ b/electron/modules/splash.js
@@ -21,9 +21,6 @@ function createSplash() {
     },
   });
 
-  // Build the splash HTML with the version baked in, write to a temp file,
-  // and load it. data: URIs don't support preload scripts, so a real file is
-  // required for contextIsolation to work.
   const iconPath = require('node:path')
     .join(__dirname, '../build/icon.png')
     .replace(/\\/g, '/');
@@ -48,64 +45,96 @@ function createSplash() {
               --progress-bg: #0a0a0a;
               --progress-fill: #ffffff;
             }
-            .splash-logo img {
-              filter: brightness(0) invert(1);
-            }
+            .splash-logo img { filter: brightness(0) invert(1); }
           }
-          body { 
-            margin: 0; padding: 0; background: transparent; overflow: hidden; 
-            display: flex; align-items: center; justify-content: center; height: 100vh; 
+          body {
+            margin: 0; padding: 0; background: transparent; overflow: hidden;
+            display: flex; align-items: center; justify-content: center; height: 100vh;
           }
-          .container { 
-            width: 280px; height: 330px; 
-            background: var(--bg-color); 
-            border-radius: 12px; border: 4px solid var(--border-color); 
-            display: flex; flex-direction: column; align-items: center; justify-content: center; 
-            padding: 20px; color: var(--text-color); text-align: center; 
+          .container {
+            width: 280px; height: 330px;
+            background: var(--bg-color);
+            border-radius: 12px; border: 4px solid var(--border-color);
+            display: flex; flex-direction: column; align-items: center; justify-content: center;
+            padding: 20px; color: var(--text-color); text-align: center;
           }
-          .splash-logo { 
-            width: 80px; height: 80px; 
-            border-radius: 12px;
-            display: flex; align-items: center; justify-content: center; 
-            margin-bottom: 24px;
-            background-color: transparent;
+          .splash-logo {
+            width: 80px; height: 80px; border-radius: 12px;
+            display: flex; align-items: center; justify-content: center;
+            margin-bottom: 16px; background-color: transparent;
           }
           .splash-logo img {
             width: 100%; height: 100%; border-radius: 12px; object-fit: contain;
           }
-          .title { 
+
+          /* Brand animation */
+          .brand-wrap {
+            display: flex; align-items: center; justify-content: center;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
             font-size: 24px; font-weight: 900; font-style: italic;
-            text-transform: uppercase; margin-bottom: 2px; letter-spacing: -0.05em; 
+            text-transform: uppercase; letter-spacing: -0.05em;
+            margin-bottom: 2px; overflow: hidden;
           }
+          .brand-n {
+            display: inline-block;
+            animation: n-drop 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards,
+                       n-bounce 0.5s 0.7s ease forwards;
+            transform: translateY(-80px);
+            opacity: 0;
+          }
+          .brand-rest {
+            display: inline-block;
+            max-width: 0; overflow: hidden; white-space: nowrap; opacity: 0;
+            animation: rest-reveal 0.5s 1.4s ease-out forwards;
+          }
+          @keyframes n-drop {
+            0% { transform: translateY(-80px); opacity: 0; }
+            20% { opacity: 1; }
+            100% { transform: translateY(0); opacity: 1; }
+          }
+          @keyframes n-bounce {
+            0% { transform: translateY(0); }
+            30% { transform: translateY(-14px); }
+            55% { transform: translateY(0); }
+            75% { transform: translateY(-5px); }
+            100% { transform: translateY(0); }
+          }
+          @keyframes rest-reveal {
+            0% { max-width: 0; opacity: 0; }
+            30% { opacity: 1; }
+            100% { max-width: 200px; opacity: 1; }
+          }
+
           .version {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
             font-size: 10px; font-weight: 700;
             color: var(--text-color); opacity: 0.6;
             margin-bottom: 24px; letter-spacing: 0.05em;
           }
-          .status { 
+          .status {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-            font-size: 12px; font-weight: 900; 
+            font-size: 12px; font-weight: 900;
             color: var(--text-color); font-style: italic;
-            max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; 
+            max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
             text-transform: uppercase; letter-spacing: 0.1em;
           }
-          .progress-bar-bg { 
-            width: 100%; height: 26px; background: var(--progress-bg); 
+          .progress-bar-bg {
+            width: 100%; height: 26px; background: var(--progress-bg);
             border: 3px solid var(--border-color); border-radius: 4px;
             margin-top: 24px; overflow: hidden; display: flex;
           }
-          .progress-bar { 
-            width: 0%; height: 100%; background: var(--progress-fill); 
-            border-right: 3px solid var(--border-color); transition: width 0.3s ease; 
+          .progress-bar {
+            width: 0%; height: 100%; background: var(--progress-fill);
+            border-right: 3px solid var(--border-color); transition: width 0.3s ease;
           }
         </style>
       </head>
       <body>
         <div class="container">
           <div class="splash-logo"><img src="file://${iconPath}" alt="Logo" /></div>
-          <div class="title">Nightwatch</div>
+          <div class="brand-wrap">
+            <span class="brand-n">N</span><span class="brand-rest">IGHTWATCH</span>
+          </div>
           <div id="version" class="version">v${getAppVersion()}</div>
           <div id="status" class="status">STARTING...</div>
           <div class="progress-bar-bg">
@@ -128,7 +157,6 @@ function createSplash() {
     </html>
 `;
 
-  // Write to a temp file so the preload script can be loaded
   const os = require('node:os');
   const splashPath = _path.join(os.tmpdir(), 'nightwatch-splash.html');
   _fs.writeFileSync(splashPath, html, 'utf-8');

--- a/src/app/(protected)/(main)/layout.tsx
+++ b/src/app/(protected)/(main)/layout.tsx
@@ -34,11 +34,15 @@ const CallOverlay = dynamic(
 type SidebarContextType = {
   leftOpen: boolean;
   rightOpen: boolean;
+  setLeftOpen: (open: boolean) => void;
+  setRightOpen: (open: boolean) => void;
 };
 
 const SidebarContext = createContext<SidebarContextType>({
   leftOpen: false,
   rightOpen: false,
+  setLeftOpen: () => {},
+  setRightOpen: () => {},
 });
 
 export const useSidebar = () => useContext(SidebarContext);
@@ -108,7 +112,9 @@ function MainLayoutInner({ children }: { children: React.ReactNode }) {
   const showOfflineBlocker = mounted && isOffline && !bypassOfflineState;
 
   return (
-    <SidebarContext.Provider value={{ leftOpen, rightOpen }}>
+    <SidebarContext.Provider
+      value={{ leftOpen, rightOpen, setLeftOpen, setRightOpen }}
+    >
       <ServerProvider defaultServer={user?.preferredServer}>
         <CallProvider>
           <div className="min-h-[100dvh] w-full bg-background text-foreground font-body flex flex-col">

--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -1,0 +1,218 @@
+import { ArrowLeft } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — Nightwatch',
+  description: 'Privacy Policy for the Nightwatch platform.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 mb-10 text-muted-foreground hover:text-foreground text-sm font-headline font-bold uppercase tracking-widest"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </Link>
+
+        <h1 className="font-headline font-black text-4xl md:text-5xl uppercase tracking-tighter mb-2">
+          Privacy Policy
+        </h1>
+        <p className="text-xs text-foreground/40 font-headline uppercase tracking-widest mb-12">
+          Last updated — April 2026
+        </p>
+
+        <div className="space-y-10 text-sm text-foreground/70 leading-relaxed">
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              1. Information We Collect
+            </h2>
+            <p>
+              When you use Nightwatch, we collect the following information:
+            </p>
+            <ul className="list-disc list-inside mt-2 space-y-1">
+              <li>
+                <strong className="text-foreground">Account data</strong> —
+                name, email address, username, and profile photo you provide
+                during registration
+              </li>
+              <li>
+                <strong className="text-foreground">Authentication data</strong>{' '}
+                — hashed passwords and HTTP-only session cookies
+              </li>
+              <li>
+                <strong className="text-foreground">Usage data</strong> — watch
+                history, watchlist items, playback preferences, and search
+                queries
+              </li>
+              <li>
+                <strong className="text-foreground">Messages</strong> — direct
+                messages and conversation metadata
+              </li>
+              <li>
+                <strong className="text-foreground">Device data</strong> —
+                browser type, operating system, screen resolution, and preferred
+                language
+              </li>
+              <li>
+                <strong className="text-foreground">Connection data</strong> —
+                IP address and approximate location for server selection
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              2. How We Use Your Data
+            </h2>
+            <ul className="list-disc list-inside space-y-1">
+              <li>Authenticate your identity and maintain your session</li>
+              <li>
+                Synchronize playback and enable real-time features (watch
+                parties, messaging, voice calls)
+              </li>
+              <li>Store your watchlist, watch history, and preferences</li>
+              <li>Deliver messages between you and your friends</li>
+              <li>Route you to the nearest server for optimal performance</li>
+              <li>Detect and prevent abuse or unauthorized access</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              3. Cookies & Local Storage
+            </h2>
+            <p>We use the following:</p>
+            <ul className="list-disc list-inside mt-2 space-y-1">
+              <li>
+                <strong className="text-foreground">
+                  HTTP-only session cookies
+                </strong>{' '}
+                — for secure authentication (cannot be accessed by JavaScript)
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  Language preference cookie
+                </strong>{' '}
+                — to remember your selected language
+              </li>
+              <li>
+                <strong className="text-foreground">Theme preference</strong> —
+                stored in localStorage to prevent flash of unstyled content
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  Service Worker cache
+                </strong>{' '}
+                — for offline functionality and faster load times
+              </li>
+            </ul>
+            <p className="mt-3">
+              We do not use third-party tracking cookies, advertising cookies,
+              or analytics services that track you across other websites.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              4. Data Sharing
+            </h2>
+            <p>
+              <strong className="text-foreground">
+                We do not sell, rent, or share your personal data with third
+                parties.
+              </strong>
+            </p>
+            <p className="mt-3">Your data may be processed by:</p>
+            <ul className="list-disc list-inside mt-2 space-y-1">
+              <li>
+                <strong className="text-foreground">Agora</strong> — for
+                real-time messaging and video call infrastructure (connection
+                metadata only)
+              </li>
+              <li>
+                <strong className="text-foreground">AWS</strong> — for cloud
+                hosting and file storage (profile photos)
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              5. Data Retention
+            </h2>
+            <p>
+              Your account data is retained for as long as your account is
+              active. Messages are stored to enable conversation history. If you
+              delete your account, your personal data will be removed from our
+              systems within 30 days, except where retention is required by law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              6. Data Security
+            </h2>
+            <p>
+              We protect your data with encrypted connections (HTTPS/TLS),
+              HTTP-only cookies, hashed passwords, and anti-bot verification.
+              While we take reasonable measures to protect your information, no
+              system is 100% secure.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              7. Your Rights
+            </h2>
+            <p>You have the right to:</p>
+            <ul className="list-disc list-inside mt-2 space-y-1">
+              <li>Access the personal data we hold about you</li>
+              <li>Request correction of inaccurate data</li>
+              <li>Request deletion of your account and associated data</li>
+              <li>Export your data</li>
+            </ul>
+            <p className="mt-3">
+              To exercise these rights, contact us through the platform or via
+              email.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              8. Content Disclaimer
+            </h2>
+            <p>
+              Nightwatch does not host, store, or distribute any media content.
+              All media is sourced externally by users. We have no control over
+              and accept no responsibility for third-party content accessed
+              through the platform. See our{' '}
+              <Link
+                href="/terms"
+                className="text-neo-yellow hover:underline underline-offset-4"
+              >
+                Terms of Service
+              </Link>{' '}
+              for more details.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              9. Changes to This Policy
+            </h2>
+            <p>
+              We may update this Privacy Policy from time to time. Continued use
+              of Nightwatch after changes constitutes acceptance of the updated
+              policy.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -1,0 +1,176 @@
+import { ArrowLeft } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — Nightwatch',
+  description: 'Terms of Service for the Nightwatch platform.',
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 mb-10 text-muted-foreground hover:text-foreground text-sm font-headline font-bold uppercase tracking-widest"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </Link>
+
+        <h1 className="font-headline font-black text-4xl md:text-5xl uppercase tracking-tighter mb-2">
+          Terms of Service
+        </h1>
+        <p className="text-xs text-foreground/40 font-headline uppercase tracking-widest mb-12">
+          Last updated — April 2026
+        </p>
+
+        <div className="space-y-10 text-sm text-foreground/70 leading-relaxed">
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              1. Acceptance of Terms
+            </h2>
+            <p>
+              By accessing or using Nightwatch, you agree to be bound by these
+              Terms of Service. If you do not agree to these terms, do not use
+              the platform. Nightwatch is a private, invite-only platform and
+              access may be revoked at any time without notice.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              2. Platform Description
+            </h2>
+            <p>
+              Nightwatch is a personal streaming companion that enables
+              synchronized media playback, watch parties, live streaming,
+              messaging, and voice calls. The platform provides tools for
+              real-time collaboration around media content.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              3. Content Disclaimer
+            </h2>
+            <p>
+              <strong className="text-foreground">
+                Nightwatch does not host, store, upload, or distribute any media
+                content.
+              </strong>{' '}
+              The platform acts solely as a synchronization and communication
+              layer. All media content is sourced externally by users.
+              Nightwatch has no control over, and assumes no responsibility for,
+              the content that users choose to watch or share through the
+              platform.
+            </p>
+            <p className="mt-3">
+              Users are solely responsible for ensuring they have the legal
+              right to access any content they view through the platform.
+              Nightwatch does not endorse, verify, or guarantee the legality of
+              any externally sourced content.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              4. User Accounts
+            </h2>
+            <p>
+              Access to Nightwatch requires an invitation. You are responsible
+              for maintaining the confidentiality of your account credentials.
+              You agree not to share your account with others or create multiple
+              accounts. We reserve the right to suspend or terminate accounts
+              that violate these terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              5. Acceptable Use
+            </h2>
+            <p>You agree not to:</p>
+            <ul className="list-disc list-inside mt-2 space-y-1">
+              <li>Use the platform for any illegal activity</li>
+              <li>
+                Attempt to reverse-engineer, exploit, or compromise the platform
+              </li>
+              <li>Harass, abuse, or harm other users</li>
+              <li>
+                Distribute malware or malicious content through messaging or
+                live streams
+              </li>
+              <li>Resell or redistribute access to the platform</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              6. Data We Collect
+            </h2>
+            <p>To provide our services, we collect:</p>
+            <ul className="list-disc list-inside mt-2 space-y-1">
+              <li>
+                <strong className="text-foreground">Account information</strong>{' '}
+                — name, email address, and profile photo
+              </li>
+              <li>
+                <strong className="text-foreground">Usage data</strong> — watch
+                history, watchlist, and playback preferences
+              </li>
+              <li>
+                <strong className="text-foreground">Messages</strong> — direct
+                messages sent through the platform
+              </li>
+              <li>
+                <strong className="text-foreground">Session data</strong> —
+                authentication tokens and session identifiers
+              </li>
+              <li>
+                <strong className="text-foreground">Device information</strong>{' '}
+                — browser type, operating system, and preferred language
+              </li>
+            </ul>
+            <p className="mt-3">
+              We do not sell your data to third parties. For full details, see
+              our{' '}
+              <Link
+                href="/privacy"
+                className="text-neo-yellow hover:underline underline-offset-4"
+              >
+                Privacy Policy
+              </Link>
+              .
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              7. Limitation of Liability
+            </h2>
+            <p>
+              Nightwatch is provided &ldquo;as is&rdquo; without warranties of
+              any kind. We are not liable for any damages arising from your use
+              of the platform, including but not limited to data loss, service
+              interruptions, or third-party content accessed through the
+              platform.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-headline font-black text-lg uppercase tracking-tight text-foreground mb-3">
+              8. Changes to Terms
+            </h2>
+            <p>
+              We may update these terms at any time. Continued use of the
+              platform after changes constitutes acceptance of the updated
+              terms.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/whats-new/page.tsx
+++ b/src/app/(public)/whats-new/page.tsx
@@ -48,7 +48,7 @@ export default async function WhatsNewPage() {
       <div className="mb-12">
         <Link
           href="/"
-          className="inline-flex items-center gap-2 mb-6 text-muted-foreground hover:text-foreground hover:underline font-mono text-sm"
+          className="inline-flex items-center gap-2 mb-10 text-muted-foreground hover:text-foreground text-sm font-headline font-bold uppercase tracking-widest"
         >
           <ArrowLeft className="w-4 h-4" />
           {t('backToHome')}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -729,6 +729,15 @@
     }
   }
 
+  @keyframes shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+
   .animate-indeterminate-progress {
     animation: indeterminate-progress 1.5s infinite linear;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,9 @@ import { OfflineIndicator } from '@/components/layout/OfflineIndicator';
 import { ProgressBar } from '@/components/layout/progress-bar';
 import { SwUpdatePrompt } from '@/components/layout/sw-update-prompt';
 import { Toaster } from '@/components/ui/sonner';
+import { SplashScreen } from '@/components/ui/splash-screen';
 import { AuthProvider } from '@/providers/auth-provider';
+
 import { IntlProvider } from '@/providers/intl-provider';
 import { SocketProvider } from '@/providers/socket-provider';
 import { ThemeProvider } from '@/providers/theme-provider';
@@ -79,6 +81,7 @@ export default async function RootLayout({
                     <DiscordPresenceSync />
                     <OfflineIndicator />
                     <SwUpdatePrompt />
+                    <SplashScreen />
                     {children}
                     <Toaster />
                   </AuthProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,379 @@
 'use client';
 
+import {
+  ArrowRight,
+  Download,
+  MessageCircle,
+  MonitorPlay,
+  Radio,
+  Shield,
+  Users,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useRootPage } from './use-root-page';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { checkIsDesktop } from '@/lib/electron-bridge';
+import { useAuth } from '@/providers/auth-provider';
 
-export default function RootPage() {
-  useRootPage();
-  const t = useTranslations('common');
+const FEATURE_ICONS = [
+  MonitorPlay,
+  Users,
+  Radio,
+  MessageCircle,
+  Download,
+  Shield,
+] as const;
+const FEATURE_KEYS = [
+  'watchTogether',
+  'watchParties',
+  'goLive',
+  'messaging',
+  'offline',
+  'secure',
+] as const;
+
+const RELEASES_API =
+  'https://api.github.com/repos/rudra-sah00/nightwatch/releases/latest';
+const RELEASES_FALLBACK =
+  'https://github.com/rudra-sah00/nightwatch/releases/latest';
+
+type DownloadLinks = { windows: string; mac: string; linux: string };
+
+function useDownloadLinks() {
+  const [links, setLinks] = useState<DownloadLinks | null>(null);
+  useEffect(() => {
+    fetch(RELEASES_API)
+      .then((r) => r.json())
+      .then((data) => {
+        const assets: { name: string; browser_download_url: string }[] =
+          data.assets ?? [];
+        const find = (test: (n: string) => boolean) =>
+          assets.find((a) => test(a.name))?.browser_download_url ??
+          RELEASES_FALLBACK;
+        setLinks({
+          windows: find((n) => n.endsWith('.exe') && !n.endsWith('.blockmap')),
+          mac: find((n) => n.endsWith('.dmg') && !n.endsWith('.blockmap')),
+          linux: find((n) => n.endsWith('.AppImage')),
+        });
+      })
+      .catch(() =>
+        setLinks({
+          windows: RELEASES_FALLBACK,
+          mac: RELEASES_FALLBACK,
+          linux: RELEASES_FALLBACK,
+        }),
+      );
+  }, []);
+  return links;
+}
+
+const PLATFORM_BUTTONS = [
+  {
+    key: 'windows' as const,
+    label: 'Windows',
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="w-5 h-5 shrink-0"
+        role="img"
+        aria-label="Windows"
+      >
+        <path d="M3 12V6.5l8-1.1V12H3zm0 5.5V12h8v6.6l-8-1.1zm9-12.9L22 3v9h-10V5.1zM22 12v9l-10 2V12h10z" />
+      </svg>
+    ),
+  },
+  {
+    key: 'mac' as const,
+    label: 'macOS',
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="w-5 h-5 shrink-0"
+        role="img"
+        aria-label="macOS"
+      >
+        <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+      </svg>
+    ),
+  },
+  {
+    key: 'linux' as const,
+    label: 'Linux',
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="w-5 h-5 shrink-0"
+        role="img"
+        aria-label="Linux"
+      >
+        <path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.368 1.884 1.43.868.07 1.723-.26 2.456-.594.733-.34 1.455-.678 2.186-.78.292-.042.594-.04.857.058a.32.32 0 00.286 0c.166-.09.296-.267.406-.466.109-.198.195-.467.305-.642.087-.174.183-.349.245-.516.06-.17.1-.334.1-.501 0-.21-.05-.39-.192-.536-.112-.12-.266-.19-.422-.23a.86.86 0 00.012-.045c.4-.88.127-1.632-.24-2.268-.376-.631-.862-1.2-1.205-1.774-.345-.576-.58-1.21-.689-2.04-.122-.93-.08-1.56-.079-2.14 0-.58.032-1.12-.18-1.68-.37-.97-1.15-1.86-2.05-2.46-.9-.6-1.94-.93-2.88-.93z" />
+      </svg>
+    ),
+  },
+];
+
+const BENTO_CONFIG = [
+  {
+    key: 'sync',
+    icon: MonitorPlay,
+    color: 'text-neo-yellow',
+    span: 'md:col-span-2 lg:col-span-2',
+    bg: 'bg-primary text-primary-foreground',
+    descColor: 'text-primary-foreground/60',
+    large: true,
+  },
+  {
+    key: 'party',
+    icon: Users,
+    color: '',
+    span: '',
+    bg: 'bg-neo-yellow text-foreground',
+    descColor: 'text-foreground/70',
+    large: false,
+  },
+  {
+    key: 'live',
+    icon: Radio,
+    color: 'text-neo-red',
+    span: '',
+    bg: 'bg-card text-foreground',
+    descColor: 'text-foreground/50',
+    large: false,
+  },
+  {
+    key: 'friends',
+    icon: MessageCircle,
+    color: 'text-neo-cyan',
+    span: '',
+    bg: 'bg-card text-foreground',
+    descColor: 'text-foreground/50',
+    large: false,
+  },
+  {
+    key: 'downloads',
+    icon: Download,
+    color: 'text-neo-green',
+    span: 'md:col-span-2 lg:col-span-1',
+    bg: 'bg-secondary text-foreground',
+    descColor: 'text-foreground/70',
+    large: false,
+  },
+] as const;
+
+export default function LandingPage() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+  const downloads = useDownloadLinks();
+  const t = useTranslations('common.landing');
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) router.replace('/home');
+    if (!isLoading && !isAuthenticated && checkIsDesktop())
+      router.replace('/login');
+  }, [isAuthenticated, isLoading, router]);
+
+  if (isLoading || isAuthenticated || checkIsDesktop()) {
+    return (
+      <div className="min-h-[100dvh] bg-background flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-border border-t-primary rounded-full animate-spin" />
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center">
-      <div className="flex flex-col items-center gap-4">
-        <div className="w-8 h-8 border-4 border-border border-t-primary rounded-full animate-spin" />
-        <p className="text-xs font-headline font-bold uppercase tracking-widest text-muted-foreground">
-          {t('loading')}
-        </p>
+    <div className="min-h-[100dvh] bg-background text-foreground font-body selection:bg-neo-yellow selection:text-foreground overflow-x-hidden">
+      <div className="fixed inset-0 pointer-events-none z-0 overflow-hidden">
+        <div className="absolute -top-[20%] -right-[10%] w-[60vw] h-[60vw] rounded-full bg-neo-yellow/[0.04]" />
+        <div className="absolute -bottom-[15%] -left-[10%] w-[50vw] h-[50vw] rounded-full bg-neo-blue/[0.03]" />
       </div>
+
+      {/* Hero */}
+      <section className="relative z-10 flex flex-col items-center justify-center min-h-[100dvh] px-6 text-center">
+        <div className="mb-8">
+          <span className="font-headline font-black italic text-3xl md:text-4xl uppercase tracking-tighter">
+            {t('brand')}
+          </span>
+        </div>
+
+        <span className="inline-block bg-neo-yellow text-foreground font-headline font-black text-[9px] md:text-[10px] uppercase tracking-[0.35em] px-4 py-1 border-4 border-border mb-10">
+          {t('badge')}
+        </span>
+
+        <h1 className="font-headline font-black text-[clamp(2.8rem,8vw,7rem)] uppercase tracking-tighter leading-[0.85] max-w-4xl">
+          {t('heroTitle1')}
+          <br />
+          <span className="text-neo-yellow">{t('heroTitle2')}</span>
+        </h1>
+
+        <p className="mt-6 text-sm md:text-base text-foreground/50 max-w-lg leading-relaxed">
+          {t('heroSubtitle')}
+        </p>
+
+        <Button
+          asChild
+          variant="neo-yellow"
+          size="none"
+          className="mt-10 px-10 py-4 text-sm uppercase tracking-[0.2em] font-headline font-black group"
+        >
+          <Link href="/login">
+            {t('login')}
+            <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </Button>
+
+        <div className="flex flex-wrap items-center justify-center gap-3 mt-16 max-w-2xl">
+          {FEATURE_KEYS.map((key, i) => {
+            const Icon = FEATURE_ICONS[i];
+            return (
+              <div
+                key={key}
+                className="flex items-center gap-2 border-[3px] border-border px-3 py-1.5 bg-card cursor-default hover:scale-105 transition-transform"
+              >
+                <Icon
+                  className="w-3.5 h-3.5 text-neo-yellow"
+                  strokeWidth={2.5}
+                />
+                <span className="font-headline font-bold uppercase text-[10px] tracking-widest whitespace-nowrap">
+                  {t(`features.${key}.title`)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Bento Features */}
+      <section className="relative z-10 px-4 md:px-8 pb-24 max-w-6xl mx-auto">
+        <h2 className="font-headline font-black text-3xl md:text-4xl uppercase tracking-tighter text-center mb-12">
+          {t('bentoTitle')}
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {BENTO_CONFIG.map((b) => {
+            const Icon = b.icon;
+            return (
+              <div
+                key={b.key}
+                className={`${b.span} ${b.bg} border-4 border-border ${b.large ? 'p-8 md:p-10' : 'p-8'} flex flex-col justify-between min-h-[220px] cursor-default`}
+              >
+                <Icon
+                  className={`w-10 h-10 ${b.color} mb-4`}
+                  strokeWidth={2.5}
+                />
+                <div>
+                  <h3
+                    className={`font-headline font-black ${b.large ? 'text-xl md:text-2xl' : 'text-lg'} uppercase tracking-tight mb-2`}
+                  >
+                    {t(`bento.${b.key}.title`)}
+                  </h3>
+                  <p
+                    className={`font-body ${b.large ? 'text-sm' : 'text-xs'} ${b.descColor} leading-relaxed ${b.large ? 'max-w-md' : ''}`}
+                  >
+                    {t(`bento.${b.key}.desc`)}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Download Desktop App */}
+      <section className="relative z-10 px-4 md:px-8 pb-24 max-w-4xl mx-auto text-center">
+        <h2 className="font-headline font-black text-3xl md:text-4xl uppercase tracking-tighter mb-3">
+          {t('downloadTitle')}
+        </h2>
+        <p className="text-sm text-foreground/50 mb-10 max-w-md mx-auto">
+          {t('downloadDesc')}
+        </p>
+        {downloads && (
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            {PLATFORM_BUTTONS.map((p) => (
+              <a
+                key={p.key}
+                href={downloads[p.key]}
+                className="flex items-center gap-3 border-4 border-border bg-card px-6 py-4 font-headline font-black uppercase text-xs tracking-widest hover:bg-primary hover:text-primary-foreground transition-colors w-full sm:w-auto justify-center"
+              >
+                {p.icon}
+                {p.label}
+              </a>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Bottom CTA */}
+      <section className="relative z-10 border-t-4 border-border bg-primary dark:bg-card">
+        <div className="max-w-4xl mx-auto px-6 py-16 md:py-20 flex flex-col items-center text-center">
+          <h2 className="font-headline font-black text-2xl md:text-4xl uppercase tracking-tighter text-primary-foreground dark:text-foreground mb-4">
+            {t('ctaTitle')}
+          </h2>
+          <p className="text-sm text-primary-foreground/50 dark:text-foreground/50 mb-8 max-w-sm">
+            {t('ctaDesc')}
+          </p>
+          <Button
+            asChild
+            variant="neo-yellow"
+            size="none"
+            className="px-10 py-4 text-sm uppercase tracking-[0.2em] font-headline font-black group"
+          >
+            <Link href="/login">
+              {t('login')}
+              <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
+            </Link>
+          </Button>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="relative z-10 bg-primary dark:bg-card border-t-4 border-border overflow-hidden">
+        <div className="px-6 md:px-12 pt-20 md:pt-28 pb-6 overflow-hidden">
+          <p
+            className="font-headline font-black italic uppercase text-[clamp(4rem,16vw,15rem)] leading-[0.78] tracking-tighter select-none text-transparent [-webkit-text-stroke:1.5px_var(--stroke-color)]"
+            style={
+              {
+                '--stroke-color': 'rgba(255,255,255,0.08)',
+              } as React.CSSProperties
+            }
+          >
+            {t('brand')}
+          </p>
+        </div>
+        <div className="px-6 md:px-12 pb-10 max-w-2xl">
+          <p className="text-[11px] text-primary-foreground/40 dark:text-foreground/30 leading-relaxed font-body">
+            {t('footer.disclaimer')}
+          </p>
+        </div>
+        <div className="border-t border-primary-foreground/10 dark:border-foreground/10 px-6 md:px-12 py-6 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+            <Link
+              href="/terms"
+              className="font-headline font-bold uppercase text-[10px] tracking-widest text-primary-foreground/50 dark:text-foreground/40 hover:text-neo-yellow transition-colors"
+            >
+              {t('footer.terms')}
+            </Link>
+            <Link
+              href="/privacy"
+              className="font-headline font-bold uppercase text-[10px] tracking-widest text-primary-foreground/50 dark:text-foreground/40 hover:text-neo-yellow transition-colors"
+            >
+              {t('footer.privacy')}
+            </Link>
+            <Link
+              href="/whats-new"
+              className="font-headline font-bold uppercase text-[10px] tracking-widest text-primary-foreground/50 dark:text-foreground/40 hover:text-neo-yellow transition-colors"
+            >
+              {t('footer.whatsNew')}
+            </Link>
+          </div>
+          <p className="font-headline font-medium uppercase text-[10px] tracking-[0.25em] text-primary-foreground/30 dark:text-foreground/20">
+            {t('footer.copyright', { year: new Date().getFullYear() })}
+          </p>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/src/components/ui/global-tour.tsx
+++ b/src/components/ui/global-tour.tsx
@@ -1,11 +1,20 @@
 'use client';
 
-import { driver } from 'driver.js';
+import { type DriveStep, driver } from 'driver.js';
 import 'driver.js/dist/driver.css';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useEffect, useRef } from 'react';
+import { useSidebar } from '@/app/(protected)/(main)/layout';
 import { useDesktopApp } from '@/hooks/use-desktop-app';
+import { useTheme } from '@/providers/theme-provider';
+
+function isDark(theme: string) {
+  if (theme === 'dark') return true;
+  if (theme === 'system' && typeof window !== 'undefined')
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return false;
+}
 
 export function GlobalTour() {
   const searchParams = useSearchParams();
@@ -13,127 +22,190 @@ export function GlobalTour() {
   const pathname = usePathname();
   const tourStarted = useRef(false);
   const { isDesktopApp } = useDesktopApp();
+  const { theme } = useTheme();
+  const { setLeftOpen, setRightOpen } = useSidebar();
   const t = useTranslations('common.tour');
 
   useEffect(() => {
     if (typeof window === 'undefined' || tourStarted.current) return;
+    if (searchParams.get('tour') !== 'true' || pathname !== '/home') return;
 
-    const isTourRequested = searchParams.get('tour') === 'true';
+    tourStarted.current = true;
 
-    // Only trigger tour on /home when the tour query param is present
-    if (isTourRequested && pathname === '/home') {
-      tourStarted.current = true;
+    const dark = isDark(theme);
+    const bg = dark ? '#18181b' : '#ffffff';
+    const fg = dark ? '#fafafa' : '#1a1a1a';
+    const overlay = dark ? 'rgba(0,0,0,0.7)' : 'rgba(0,0,0,0.5)';
 
-      const timer = setTimeout(() => {
-        const driverObj = driver({
-          showProgress: true,
-          animate: true,
-          allowClose: true,
-          overlayColor: 'rgba(0,0,0,0.5)',
-          popoverClass:
-            'rounded-xl border border-gray-200 shadow-lg !font-body',
-          steps: [
-            {
-              popover: {
-                title: `<span class="font-headline font-black text-xl uppercase tracking-tighter">${t('welcome.title')}</span>`,
-                description: `<span class="font-body text-sm font-medium opacity-80">${t('welcome.description')}</span>`,
-                side: 'bottom',
-                align: 'center',
-              },
-            },
-            {
-              element: 'input[name="q"]',
-              popover: {
-                title: `<span class="font-headline font-black text-xl uppercase tracking-tighter">${t('search.title')}</span>`,
-                description: `<span class="font-body text-sm font-medium opacity-80">${t('search.description')}</span>`,
-                side: 'bottom',
-                align: 'start',
-              },
-            },
-            {
-              element: 'a[href="/continue-watching"]',
-              popover: {
-                title: `<span class="font-headline font-black text-xl uppercase tracking-tighter">${t('resume.title')}</span>`,
-                description: `<span class="font-body text-sm font-medium opacity-80">${t('resume.description')}</span>`,
-                side: 'bottom',
-                align: 'center',
-              },
-            },
-            {
-              element: 'a[href="/live"]',
-              popover: {
-                title: `<span class="font-headline font-black text-xl uppercase tracking-tighter">${t('live.title')}</span>`,
-                description: `<span class="font-body text-sm font-medium opacity-80">${t('live.description')}</span>`,
-                side: 'bottom',
-                align: 'center',
-              },
-            },
-            {
-              element: 'a[href="/watchlist"]',
-              popover: {
-                title: `<span class="font-headline font-black text-xl uppercase tracking-tighter">${t('watchlist.title')}</span>`,
-                description: `<span class="font-body text-sm font-medium opacity-80">${t('watchlist.description')}</span>`,
-                side: 'bottom',
-                align: 'center',
-              },
-            },
-            ...(isDesktopApp
-              ? [
-                  {
-                    element: 'a[href="/downloads"]',
-                    popover: {
-                      title: `<span class="font-headline font-black text-xl uppercase tracking-tighter">${t('downloads.title')}</span>`,
-                      description: `<span class="font-body text-sm font-medium opacity-80">${t('downloads.description')}</span>`,
-                      side: 'bottom' as const,
-                      align: 'center' as const,
-                    },
-                  },
-                ]
-              : []),
-            {
-              element: 'a[href="/profile"]',
-              popover: {
-                title: `<span class="font-headline font-black text-xl uppercase tracking-tighter">${t('profile.title')}</span>`,
-                description: `<span class="font-body text-sm font-medium opacity-80">${t('profile.description')}</span>`,
-                side: 'bottom',
-                align: 'end',
-              },
-            },
-            {
-              element: 'a[href="/profile"]',
-              popover: {
-                title: `<span class="font-headline font-black text-xl text-neo-red uppercase tracking-tighter">${t('serverTip.title')}</span>`,
-                description: `<span class="font-body text-sm font-medium opacity-80">${t('serverTip.description')}</span>`,
-                side: 'bottom',
-                align: 'end',
-              },
-            },
-            {
-              popover: {
-                title: `<span class="font-headline font-black text-xl uppercase tracking-tighter">${t('ready.title')}</span>`,
-                description: `<span class="font-body text-sm font-medium opacity-80">${t('ready.description')}</span>`,
-                side: 'bottom',
-                align: 'center',
-              },
-            },
-          ],
-          onDestroyStarted: () => {
-            // Remove the parameter silently
-            const newParams = new URLSearchParams(searchParams.toString());
-            newParams.delete('tour');
-            router.replace(
-              `${pathname}${newParams.toString() ? `?${newParams.toString()}` : ''}`,
-            );
-            driverObj.destroy();
+    const title = (text: string, color?: string) =>
+      `<span class="font-headline font-black text-xl uppercase tracking-tighter" style="color:${color ?? fg}">${text}</span>`;
+    const desc = (text: string) =>
+      `<span class="font-body text-sm font-medium" style="color:${fg};opacity:0.7">${text}</span>`;
+
+    const timer = setTimeout(() => {
+      const steps: DriveStep[] = [
+        {
+          popover: {
+            title: title(t('welcome.title')),
+            description: desc(t('welcome.description')),
           },
-        });
+        },
+        {
+          element: 'input[name="q"]',
+          popover: {
+            title: title(t('search.title')),
+            description: desc(t('search.description')),
+            side: 'bottom',
+            align: 'start',
+          },
+        },
+        // Open left sidebar and highlight it
+        {
+          element: 'aside',
+          popover: {
+            title: title(t('sidebar.title')),
+            description: desc(t('sidebar.description')),
+            side: 'right',
+            align: 'start',
+          },
+          onHighlightStarted: () => setLeftOpen(true),
+        },
+        {
+          element: 'a[href="/continue-watching"]',
+          popover: {
+            title: title(t('resume.title')),
+            description: desc(t('resume.description')),
+            side: 'right',
+            align: 'center',
+          },
+        },
+        {
+          element: 'a[href="/live"]',
+          popover: {
+            title: title(t('live.title')),
+            description: desc(t('live.description')),
+            side: 'right',
+            align: 'center',
+          },
+        },
+        {
+          element: 'a[href="/watchlist"]',
+          popover: {
+            title: title(t('watchlist.title')),
+            description: desc(t('watchlist.description')),
+            side: 'right',
+            align: 'center',
+          },
+        },
+        ...(isDesktopApp
+          ? [
+              {
+                element: 'a[href="/downloads"]',
+                popover: {
+                  title: title(t('downloads.title')),
+                  description: desc(t('downloads.description')),
+                  side: 'right' as const,
+                  align: 'center' as const,
+                },
+              },
+            ]
+          : []),
+        // Close left, open right sidebar for friends
+        {
+          element: 'aside:last-of-type',
+          popover: {
+            title: title(t('friends.title')),
+            description: desc(t('friends.description')),
+            side: 'left',
+            align: 'start',
+          },
+          onHighlightStarted: () => {
+            setLeftOpen(false);
+            setRightOpen(true);
+          },
+        },
+        {
+          element: 'a[href="/messages"]',
+          popover: {
+            title: title(t('messages.title')),
+            description: desc(t('messages.description')),
+            side: 'left',
+            align: 'center',
+          },
+        },
+        // Close right sidebar, show profile
+        {
+          element: 'a[href="/profile"]',
+          popover: {
+            title: title(t('profile.title')),
+            description: desc(t('profile.description')),
+            side: 'bottom',
+            align: 'end',
+          },
+          onHighlightStarted: () => setRightOpen(false),
+        },
+        {
+          element: 'a[href="/profile"]',
+          popover: {
+            title: title(t('serverTip.title'), dark ? '#fb7185' : '#e63b2e'),
+            description: desc(t('serverTip.description')),
+            side: 'bottom',
+            align: 'end',
+          },
+        },
+        {
+          popover: {
+            title: title(t('ready.title')),
+            description: desc(t('ready.description')),
+          },
+        },
+      ];
 
-        driverObj.drive();
-      }, 500);
+      const driverObj = driver({
+        showProgress: true,
+        animate: true,
+        allowClose: true,
+        overlayColor: overlay,
+        popoverClass: `rounded-xl border-2 shadow-xl !font-body`,
+        stagePadding: 8,
+        stageRadius: 12,
+        popoverOffset: 12,
+        progressText: `{{current}} / {{total}}`,
+        nextBtnText: t('nextBtn'),
+        prevBtnText: t('prevBtn'),
+        doneBtnText: t('doneBtn'),
+        steps,
+        onPopoverRender: (popover) => {
+          const el = popover.wrapper as HTMLElement;
+          el.style.backgroundColor = bg;
+          el.style.borderColor = dark ? '#27272a' : '#e4e4e7';
+        },
+        onDestroyStarted: () => {
+          setLeftOpen(false);
+          setRightOpen(false);
+          const newParams = new URLSearchParams(searchParams.toString());
+          newParams.delete('tour');
+          router.replace(
+            `${pathname}${newParams.toString() ? `?${newParams.toString()}` : ''}`,
+          );
+          driverObj.destroy();
+        },
+      });
 
-      return () => clearTimeout(timer);
-    }
-  }, [searchParams, pathname, router, isDesktopApp, t]);
+      driverObj.drive();
+    }, 600);
+
+    return () => clearTimeout(timer);
+  }, [
+    searchParams,
+    pathname,
+    router,
+    isDesktopApp,
+    t,
+    theme,
+    setLeftOpen,
+    setRightOpen,
+  ]);
 
   return null;
 }

--- a/src/components/ui/splash-screen.tsx
+++ b/src/components/ui/splash-screen.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function SplashScreen() {
+  const [show, setShow] = useState(true);
+  const [fadeOut, setFadeOut] = useState(false);
+
+  useEffect(() => {
+    const fadeTimer = setTimeout(() => setFadeOut(true), 2000);
+    const hideTimer = setTimeout(() => setShow(false), 2500);
+    return () => {
+      clearTimeout(fadeTimer);
+      clearTimeout(hideTimer);
+    };
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 z-[200] bg-background flex items-center justify-center transition-opacity duration-500 ease-out ${fadeOut ? 'opacity-0' : 'opacity-100'}`}
+    >
+      <span
+        className="font-headline font-black italic uppercase tracking-tighter text-[clamp(2.5rem,7vw,4.5rem)] select-none text-transparent pr-[0.15em] bg-[length:200%_100%] bg-clip-text animate-[shimmer_2s_ease-in-out_infinite] bg-[linear-gradient(110deg,transparent_35%,hsl(var(--foreground)/0.15)_50%,transparent_65%)]"
+        style={{ WebkitTextStroke: '1.5px hsl(var(--foreground))' }}
+      >
+        NIGHTWATCH
+      </span>
+    </div>
+  );
+}

--- a/src/features/friends/components/MessagesClient.tsx
+++ b/src/features/friends/components/MessagesClient.tsx
@@ -48,7 +48,7 @@ export function MessagesClient() {
   }, [friendParam, router]);
 
   return (
-    <div className="flex gap-4 h-[calc(100vh-8rem)] max-w-5xl mx-auto w-full">
+    <div className="flex gap-4 h-[calc(100vh-8rem)] w-full p-4">
       <ConversationList
         selected={selectedFriend}
         onSelect={setSelectedFriend}

--- a/src/i18n/messages/ar/common.json
+++ b/src/i18n/messages/ar/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "أنت جاهز",
       "description": "استمتع بالتجربة السينمائية النقية. بدون تشتيت. فقط أفلام."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "هوية المنشئ",
@@ -283,6 +298,74 @@
       "reply": "رد",
       "emoji": "إيموجي",
       "callButton": "اتصال"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/de/common.json
+++ b/src/i18n/messages/de/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "Du bist bereit",
       "description": "Genieße das pure Kinoerlebnis. Keine Ablenkungen. Nur Film."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "Ersteller-Identität",
@@ -283,6 +298,74 @@
       "reply": "Antworten",
       "emoji": "Emoji",
       "callButton": "Anrufen"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/en/common.json
+++ b/src/i18n/messages/en/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "You are ready",
       "description": "Enjoy the pure cinematic experience. No distractions. Just film."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "Creator Identity",
@@ -283,6 +298,74 @@
       "reply": "Reply",
       "emoji": "Emoji",
       "callButton": "Call"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/es/common.json
+++ b/src/i18n/messages/es/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "Estás listo",
       "description": "Disfruta la experiencia cinematográfica pura. Sin distracciones. Solo cine."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "Identidad del Creador",
@@ -283,6 +298,74 @@
       "reply": "Responder",
       "emoji": "Emoji",
       "callButton": "Llamar"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/fr/common.json
+++ b/src/i18n/messages/fr/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "Vous êtes prêt",
       "description": "Profitez de l'expérience cinématographique pure. Pas de distractions. Juste du cinéma."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "Identité du Créateur",
@@ -283,6 +298,74 @@
       "reply": "Répondre",
       "emoji": "Emoji",
       "callButton": "Appeler"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/hi/common.json
+++ b/src/i18n/messages/hi/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "आप तैयार हैं",
       "description": "शुद्ध सिनेमाई अनुभव का आनंद लें। कोई विकर्षण नहीं। बस फिल्म।"
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "निर्माता पहचान",
@@ -283,6 +298,74 @@
       "reply": "जवाब",
       "emoji": "इमोजी",
       "callButton": "कॉल"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/it/common.json
+++ b/src/i18n/messages/it/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "Sei pronto",
       "description": "Goditi l'esperienza cinematografica pura. Nessuna distrazione. Solo cinema."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "Identità del Creatore",
@@ -283,6 +298,74 @@
       "reply": "Rispondi",
       "emoji": "Emoji",
       "callButton": "Chiama"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/ja/common.json
+++ b/src/i18n/messages/ja/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "準備完了",
       "description": "純粋な映画体験をお楽しみください。邪魔なし。映画だけ。"
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "クリエイター情報",
@@ -283,6 +298,74 @@
       "reply": "返信",
       "emoji": "絵文字",
       "callButton": "通話"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/ko/common.json
+++ b/src/i18n/messages/ko/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "준비 완료",
       "description": "순수한 시네마 경험을 즐기세요. 방해 없이. 오직 영화만."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "크리에이터 정보",
@@ -283,6 +298,74 @@
       "reply": "답장",
       "emoji": "이모지",
       "callButton": "전화"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/pt/common.json
+++ b/src/i18n/messages/pt/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "Você está pronto",
       "description": "Aproveite a experiência cinematográfica pura. Sem distrações. Apenas cinema."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "Identidade do Criador",
@@ -283,6 +298,74 @@
       "reply": "Responder",
       "emoji": "Emoji",
       "callButton": "Ligar"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/ru/common.json
+++ b/src/i18n/messages/ru/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "Вы готовы",
       "description": "Наслаждайтесь чистым кинематографическим опытом. Без отвлечений. Только кино."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "Личность создателя",
@@ -283,6 +298,74 @@
       "reply": "Ответить",
       "emoji": "Эмодзи",
       "callButton": "Позвонить"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/th/common.json
+++ b/src/i18n/messages/th/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "คุณพร้อมแล้ว",
       "description": "เพลิดเพลินกับประสบการณ์ภาพยนตร์บริสุทธิ์ ไม่มีสิ่งรบกวน มีแต่ภาพยนตร์"
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "ตัวตนผู้สร้าง",
@@ -283,6 +298,74 @@
       "reply": "ตอบ",
       "emoji": "อิโมจิ",
       "callButton": "โทร"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/tr/common.json
+++ b/src/i18n/messages/tr/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "Hazırsınız",
       "description": "Saf sinema deneyiminin tadını çıkarın. Dikkat dağıtıcı yok. Sadece film."
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "Yaratıcı Kimliği",
@@ -283,6 +298,74 @@
       "reply": "Yanıtla",
       "emoji": "Emoji",
       "callButton": "Ara"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }

--- a/src/i18n/messages/zh/common.json
+++ b/src/i18n/messages/zh/common.json
@@ -95,7 +95,22 @@
     "ready": {
       "title": "您已准备就绪",
       "description": "享受纯粹的电影体验。没有干扰。只有电影。"
-    }
+    },
+    "sidebar": {
+      "title": "Navigation",
+      "description": "Your main menu lives here. Hover the left edge anytime to open it."
+    },
+    "friends": {
+      "title": "Friends & Social",
+      "description": "Your friends list, online status, and friend requests. Hover the right edge to open it anytime."
+    },
+    "messages": {
+      "title": "Messages",
+      "description": "Send direct messages, make voice calls, and stay connected with friends."
+    },
+    "nextBtn": "Next",
+    "prevBtn": "Back",
+    "doneBtn": "Let's Go!"
   },
   "creatorFooter": {
     "title": "创作者身份",
@@ -283,6 +298,74 @@
       "reply": "回复",
       "emoji": "表情",
       "callButton": "通话"
+    }
+  },
+  "landing": {
+    "brand": "Nightwatch",
+    "badge": "Invite Only Beta",
+    "heroTitle1": "Watch Anything",
+    "heroTitle2": "Together",
+    "heroSubtitle": "Synchronized playback, real-time watch parties, live streaming, voice calls, and messaging — all in one place.",
+    "login": "Login",
+    "features": {
+      "watchTogether": {
+        "title": "Watch Together",
+        "desc": "Synchronized playback with friends in real-time."
+      },
+      "watchParties": {
+        "title": "Watch Parties",
+        "desc": "Video calls and shared controls over WebRTC."
+      },
+      "goLive": {
+        "title": "Go Live",
+        "desc": "Stream to your audience with RTMP and live chat."
+      },
+      "messaging": {
+        "title": "Messaging",
+        "desc": "DMs, voice calls, and online presence."
+      },
+      "offline": {
+        "title": "Offline Mode",
+        "desc": "Download and watch anywhere, anytime."
+      },
+      "secure": {
+        "title": "Private & Secure",
+        "desc": "Encrypted sessions with invite-only access."
+      }
+    },
+    "bentoTitle": "Everything You Need",
+    "bento": {
+      "sync": {
+        "title": "Synchronized Playback",
+        "desc": "Watch movies, shows, and videos perfectly in sync with anyone. Play, pause, and seek — everyone stays on the same frame."
+      },
+      "party": {
+        "title": "Watch Parties",
+        "desc": "Peer-to-peer video calls with shared controls. See reactions in real-time over WebRTC."
+      },
+      "live": {
+        "title": "Go Live",
+        "desc": "Stream with RTMP ingestion, HLS delivery, and real-time chat with your audience."
+      },
+      "friends": {
+        "title": "Friends & Messaging",
+        "desc": "DMs, voice calls, online presence, and friend requests — stay connected."
+      },
+      "downloads": {
+        "title": "Offline Downloads",
+        "desc": "Download content to your device. Watch anywhere — no internet required."
+      }
+    },
+    "downloadTitle": "Get the Desktop App",
+    "downloadDesc": "Picture-in-Picture, media keys, offline downloads, and Discord Rich Presence — available on all platforms.",
+    "ctaTitle": "Ready to Watch?",
+    "ctaDesc": "Nightwatch is currently invite-only. Log in with your account to get started.",
+    "footer": {
+      "disclaimer": "Nightwatch does not host, store, upload, or distribute any media content. All content is sourced externally by users. The platform serves solely as a synchronization and communication layer. We are not responsible for any third-party content accessed through the platform.",
+      "terms": "Terms",
+      "privacy": "Privacy",
+      "whatsNew": "What's New",
+      "copyright": "© {year} Nightwatch. All rights reserved."
     }
   }
 }


### PR DESCRIPTION
…fixes

- Landing page: product showcase at / with hero, features bento grid, desktop download buttons (direct links from GitHub releases API), bottom CTA, big-text footer with disclaimer. Fully i18n'd (14 langs). Desktop app skips landing and goes straight to /login.

- Splash screen: NIGHTWATCH text with shimmer animation on every page load, rendered in root layout. Electron splash updated with matching N-bounce-reveal animation.

- Onboarding tour: driver.js tour now auto-opens left sidebar for nav steps and right sidebar for friends/messages. Theme-aware popover colors. i18n button labels (Next/Back/Done). New steps: sidebar, friends, messages.

- Legal pages: /terms and /privacy with full content (content disclaimer, data collection, acceptable use, cookies, data sharing, user rights).

- Messages page: removed max-w-5xl constraint, stretched to full width with equal padding.

- Sidebar context: exposed setLeftOpen/setRightOpen for programmatic control.

- Whats-new: back button style aligned with terms/privacy pages.

- i18n: added landing + tour keys to all 14 language files.

- Biome + TypeScript: all clean, zero errors.