### PR TITLE
fix: compute activity graph month labels dynamically

### DIFF
--- a/src/features/profile/components/activity-graph.tsx
+++ b/src/features/profile/components/activity-graph.tsx
@@ -26,12 +26,69 @@ const ACTIVITY_LEVEL_COLORS = [
   'bg-neo-red', // Level 4
 ] as const;
 
+const MONTH_KEYS = [
+  'jan',
+  'feb',
+  'mar',
+  'apr',
+  'may',
+  'jun',
+  'jul',
+  'aug',
+  'sep',
+  'oct',
+  'nov',
+  'dec',
+] as const;
+
+function getMonthLabelsFromWeeks(
+  weeks: { date: Date }[][],
+  t: (key: string) => string,
+) {
+  const labels: { key: string; label: string }[] = [];
+  let lastMonth = -1;
+  for (const week of weeks) {
+    const month = week[0].date.getMonth();
+    if (month !== lastMonth) {
+      lastMonth = month;
+      labels.push({
+        key: `${month}-${week[0].date.getFullYear()}`,
+        label: t(`activity.months.${MONTH_KEYS[month]}`),
+      });
+    }
+  }
+  return labels;
+}
+
+function getMonthLabelsForSkeleton(t: (key: string) => string) {
+  const today = new Date();
+  const dayOfWeek = today.getDay();
+  const start = new Date(today);
+  start.setDate(today.getDate() - (52 * 7 + dayOfWeek));
+  const labels: { key: string; label: string }[] = [];
+  let lastMonth = -1;
+  for (let w = 0; w < 53; w++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + w * 7);
+    const month = d.getMonth();
+    if (month !== lastMonth) {
+      lastMonth = month;
+      labels.push({
+        key: `${month}-${d.getFullYear()}`,
+        label: t(`activity.months.${MONTH_KEYS[month]}`),
+      });
+    }
+  }
+  return labels;
+}
+
 function ActivityGraphSkeleton() {
   const t = useTranslations('profile');
   const skeletonIds = useMemo(
     () => Array.from({ length: 53 * 7 }).map((_, i) => `skel-id-${i}`),
     [],
   );
+  const monthLabels = useMemo(() => getMonthLabelsForSkeleton(t), [t]);
 
   return (
     <div className="w-full animate-pulse">
@@ -44,18 +101,9 @@ function ActivityGraphSkeleton() {
         ))}
       </div>
       <div className="flex justify-between mt-4 text-[10px] font-bold uppercase font-headline text-foreground/20">
-        <span>{t('activity.months.jan')}</span>
-        <span>{t('activity.months.feb')}</span>
-        <span>{t('activity.months.mar')}</span>
-        <span>{t('activity.months.apr')}</span>
-        <span>{t('activity.months.may')}</span>
-        <span>{t('activity.months.jun')}</span>
-        <span>{t('activity.months.jul')}</span>
-        <span>{t('activity.months.aug')}</span>
-        <span>{t('activity.months.sep')}</span>
-        <span>{t('activity.months.oct')}</span>
-        <span>{t('activity.months.nov')}</span>
-        <span>{t('activity.months.dec')}</span>
+        {monthLabels.map((m) => (
+          <span key={m.key}>{m.label}</span>
+        ))}
       </div>
     </div>
   );
@@ -143,6 +191,10 @@ export function ActivityGraph({
   const t = useTranslations('profile');
   const locale = useLocale();
   const { weeks } = useActivityGraphData(activity, createdAt);
+  const monthLabels = useMemo(
+    () => getMonthLabelsFromWeeks(weeks, t),
+    [weeks, t],
+  );
 
   const formatDate = (date: Date) =>
     date.toLocaleDateString(locale, {
@@ -232,18 +284,9 @@ export function ActivityGraph({
         )}
       </div>
       <div className="flex justify-between mt-4 text-[10px] font-bold uppercase font-headline text-foreground/40">
-        <span>{t('activity.months.jan')}</span>
-        <span>{t('activity.months.feb')}</span>
-        <span>{t('activity.months.mar')}</span>
-        <span>{t('activity.months.apr')}</span>
-        <span>{t('activity.months.may')}</span>
-        <span>{t('activity.months.jun')}</span>
-        <span>{t('activity.months.jul')}</span>
-        <span>{t('activity.months.aug')}</span>
-        <span>{t('activity.months.sep')}</span>
-        <span>{t('activity.months.oct')}</span>
-        <span>{t('activity.months.nov')}</span>
-        <span>{t('activity.months.dec')}</span>
+        {monthLabels.map((m) => (
+          <span key={m.key}>{m.label}</span>
+        ))}
       </div>
     </>
   );

--- a/tests/features/profile/components/activity-graph.test.tsx
+++ b/tests/features/profile/components/activity-graph.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ActivityGraph } from '@/features/profile/components/activity-graph';
 import type { WatchActivity } from '@/features/profile/types';
@@ -14,7 +14,11 @@ describe('ActivityGraph', () => {
   describe('rendering', () => {
     it('renders without crashing', () => {
       render(<ActivityGraph activity={[]} />);
-      expect(screen.getByText('activity.months.jan')).toBeInTheDocument();
+      // Month labels are now dynamic based on the 53-week range ending today
+      const monthContainer = document.querySelector(
+        '.flex.justify-between.mt-4',
+      );
+      expect(monthContainer).toBeInTheDocument();
     });
 
     it('renders loading skeleton when isLoading is true', () => {
@@ -33,10 +37,17 @@ describe('ActivityGraph', () => {
   });
 
   describe('legend', () => {
-    it('renders the months', () => {
+    it('renders dynamic month labels matching the date range', () => {
       render(<ActivityGraph activity={mockActivity} />);
-      expect(screen.getByText('activity.months.jan')).toBeInTheDocument();
-      expect(screen.getByText('activity.months.dec')).toBeInTheDocument();
+      // The graph covers ~53 weeks ending today, so it should show
+      // roughly 12-13 month labels spanning that range, not a fixed Jan-Dec
+      const monthContainer = document.querySelector(
+        '.flex.justify-between.mt-4',
+      );
+      expect(monthContainer).toBeInTheDocument();
+      const spans = monthContainer!.querySelectorAll('span');
+      expect(spans.length).toBeGreaterThanOrEqual(12);
+      expect(spans.length).toBeLessThanOrEqual(14);
     });
   });
 
@@ -66,8 +77,11 @@ describe('ActivityGraph', () => {
   describe('empty state', () => {
     it('renders correctly with empty activity array', () => {
       render(<ActivityGraph activity={[]} />);
-      // Should show Jan/Dec
-      expect(screen.getByText('activity.months.jan')).toBeInTheDocument();
+      // Should show dynamic month labels
+      const monthContainer = document.querySelector(
+        '.flex.justify-between.mt-4',
+      );
+      expect(monthContainer).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
The month labels below the watch activity heatmap were hardcoded as Jan–Dec, but the graph displays the last 53 weeks from today. This caused months to be completely misaligned with the actual data columns on both the profile route and public user profile.

## Changes
- Derive month labels dynamically from the weeks data by detecting month boundaries
- Apply the same dynamic logic to the skeleton loading state
- Remove unused `screen` import from tests

## Testing
- All 72 profile tests pass
- Biome check passes with 0 errors/warnings across 627 files
- Pre-commit hooks (type-check + biome) pass