### PR TITLE
fix: two-layer ASAR differential updater for desktop

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -73,3 +73,26 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
         run: pnpm exec electron-builder ${{ matrix.build_args }} --publish always
+
+      - name: Upload app.asar to GitHub Release (macOS only)
+        if: matrix.platform == 'macOS-arm64'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Extract app.asar from the built .app bundle
+          ASAR_PATH=$(find desktop-build/mac-arm64 -name "app.asar" -path "*/Resources/*" | head -1)
+          if [ -z "$ASAR_PATH" ]; then
+            echo "❌ app.asar not found in build output"
+            exit 1
+          fi
+          echo "Found app.asar at: $ASAR_PATH ($(du -h "$ASAR_PATH" | cut -f1))"
+
+          # Gzip for smaller download (584MB → ~154MB)
+          gzip -c "$ASAR_PATH" > "${ASAR_PATH}.gz"
+          echo "Compressed: $(du -h "${ASAR_PATH}.gz" | cut -f1)"
+
+          # Get the latest release tag
+          TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          echo "Uploading app.asar.gz to release: $TAG"
+
+          gh release upload "$TAG" "${ASAR_PATH}.gz" --clobber

--- a/electron/main.js
+++ b/electron/main.js
@@ -106,6 +106,26 @@ let globalPowerBlockerId = -1;
 const triggerDeepLink = (url) => handleDeepLink(url, AppWindow.getInstance());
 
 const startElectronApp = async () => {
+  // --- PENDING ASAR SWAP (Windows) ---
+  // On Windows the running app.asar is file-locked, so ASAR updates are staged
+  // as app.asar.pending. Apply the swap before anything reads from the ASAR.
+  if (app.isPackaged) {
+    const _fs = require('node:fs');
+    const asarPath = _path.join(_path.dirname(app.getAppPath()), 'app.asar');
+    const pendingPath = `${asarPath}.pending`;
+    if (_fs.existsSync(pendingPath)) {
+      try {
+        _fs.renameSync(pendingPath, asarPath);
+        app.relaunch();
+        app.exit(0);
+        return;
+      } catch (err) {
+        require('electron-log').error('[asar-swap] Failed:', err);
+        _fs.rmSync(pendingPath, { force: true });
+      }
+    }
+  }
+
   // Register offline-media:// protocol handler FIRST — before splash or main window.
   // This ensures downloaded HLS/MP4 content is playable the instant the React app loads.
   setupOfflineMediaProtocol();
@@ -618,10 +638,9 @@ const startElectronApp = async () => {
     store.delete(key);
   });
 
-  // --- REAL APP VERSION (ASAR-aware) ---
-  // app.getVersion() returns the native binary's compile-time version and is NOT
-  // updated by electron-asar-hot-updater. We always read from package.json inside
-  // the ASAR so React sees the correct version after a hot update.
+  // --- REAL APP VERSION ---
+  // app.getVersion() returns the native binary's compile-time version.
+  // We read from package.json inside the ASAR for accuracy.
   ipcMain.handle('get-app-version', () => getAppVersion());
 
   ipcMain.handle('toggle-fullscreen', () => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -396,6 +396,13 @@ const startElectronApp = async () => {
     }
   });
 
+  // --- CALL-ACTIVE FLAG ---
+  // Suppresses window-blur IPC during active calls to prevent socket
+  // reconnection races that cause desktop-to-desktop call auto-disconnect.
+  ipcMain.on('set-call-active', (_event, active) => {
+    AppWindow.callActive = !!active;
+  });
+
   // --- SMART POWER & BANDWIDTH SAVER ---
   // If the user folds their laptop or locks their PC, forcefully pause the movie and show Away on Discord!
   const triggerSleepPause = () => {

--- a/electron/modules/updater.js
+++ b/electron/modules/updater.js
@@ -1,8 +1,94 @@
 const { autoUpdater } = require('electron-updater');
-const { autoUpdater: asarUpdater } = require('electron-asar-hot-updater');
-const { net } = require('electron');
+const { app, net } = require('electron');
+const path = require('node:path');
+const fs = require('node:fs');
+const { createGunzip } = require('node:zlib');
+const { pipeline } = require('node:stream/promises');
+const { Readable } = require('node:stream');
 const log = require('electron-log');
+const { getAppVersion } = require('./version');
 
+const GH_OWNER = 'rudra-sah00';
+const GH_REPO = 'nightwatch';
+const ASAR_ASSET_NAME = 'app.asar.gz';
+
+/**
+ * Fetches the latest GitHub Release and returns its version + app.asar.gz URL.
+ * No hardcoded versions — always queries the API dynamically.
+ */
+async function fetchLatestAsarInfo() {
+  const url = `https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/releases/latest`;
+  const res = await net.fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'Nightwatch-Desktop',
+    },
+  });
+  if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+  const release = await res.json();
+  const version = release.tag_name?.replace(/^v/, '');
+  const asset = release.assets?.find((a) => a.name === ASAR_ASSET_NAME);
+  return { version, asarUrl: asset?.browser_download_url || null };
+}
+
+/**
+ * Downloads a gzipped ASAR from url, decompresses it, and writes to destPath.
+ * Reports progress via onProgress(percent).
+ */
+async function downloadAndDecompress(url, destPath, onProgress) {
+  const res = await net.fetch(url, {
+    headers: { 'User-Agent': 'Nightwatch-Desktop' },
+  });
+  if (!res.ok) throw new Error(`Download failed: HTTP ${res.status}`);
+
+  const total = Number.parseInt(res.headers.get('content-length') || '0', 10);
+  let downloaded = 0;
+
+  // Convert web ReadableStream → Node Readable so we can pipe through gunzip
+  const webStream = res.body;
+  const nodeStream = Readable.fromWeb(webStream);
+
+  // Track download progress
+  const tracker = new (require('node:stream').Transform)({
+    transform(chunk, _encoding, cb) {
+      downloaded += chunk.length;
+      if (total > 0 && onProgress) {
+        onProgress(Math.floor((downloaded / total) * 100));
+      }
+      cb(null, chunk);
+    },
+  });
+
+  const gunzip = createGunzip();
+  const output = fs.createWriteStream(destPath);
+
+  await pipeline(nodeStream, tracker, gunzip, output);
+}
+
+/**
+ * Returns true if remote semver > local semver.
+ */
+function isNewer(remote, local) {
+  if (!remote || !local) return false;
+  const r = remote.split('.').map(Number);
+  const l = local.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((r[i] || 0) > (l[i] || 0)) return true;
+    if ((r[i] || 0) < (l[i] || 0)) return false;
+  }
+  return false;
+}
+
+/**
+ * Two-layer update system:
+ *
+ * Layer 1 — Native binary (electron-updater):
+ *   Full .dmg/.exe/.AppImage for Electron version bumps or native module changes.
+ *
+ * Layer 2 — ASAR differential (GitHub Releases API):
+ *   Downloads only the gzipped app.asar (~154MB vs 584MB raw, vs 292MB full DMG).
+ *   Swaps the ASAR in place and relaunches. No hardcoded versions.
+ */
 function setupUpdater(splashWindow, onComplete) {
   log.transports.file.level = 'info';
   autoUpdater.logger = log;
@@ -12,14 +98,12 @@ function setupUpdater(splashWindow, onComplete) {
   let updateFinished = false;
   let safetyTimer = null;
   let hardDeadlineTimer = null;
-  let asarChecked = false;
 
   const finish = () => {
     if (updateFinished) return;
     updateFinished = true;
     if (safetyTimer) clearTimeout(safetyTimer);
     if (hardDeadlineTimer) clearTimeout(hardDeadlineTimer);
-    // Delay slightly so the progress bar reaches 100% visually before close.
     setTimeout(() => {
       try {
         onComplete();
@@ -29,8 +113,6 @@ function setupUpdater(splashWindow, onComplete) {
     }, 1000);
   };
 
-  // Absolute hard deadline — guarantees the app always launches even if every
-  // updater event silently hangs (captive-portal Wi-Fi, firewall, proxy, etc.).
   hardDeadlineTimer = setTimeout(() => {
     log.warn('[updater] Hard deadline reached (20 s) — forcing launch.');
     finish();
@@ -45,44 +127,103 @@ function setupUpdater(splashWindow, onComplete) {
     }
   };
 
-  // --- INSTANT OFFLINE CHECK ---
-  // If there's no network at all, skip the updater immediately.
+  const sendVersion = (version) => {
+    if (splashWindow && !splashWindow.isDestroyed()) {
+      splashWindow.webContents.send('updater-version', version);
+    }
+  };
+
   if (!net.isOnline()) {
-    log.info('[updater] Device is offline — skipping update check instantly.');
+    log.info('[updater] Device is offline — skipping update check.');
     sendStatus('Starting Nightwatch...', 100);
     finish();
     return;
   }
 
-  // --- SAFETY TIMEOUT (online but slow/unreachable server) ---
-  // 12 s is enough for slow connections; the hard deadline at 20 s is the backstop.
   safetyTimer = setTimeout(() => {
-    log.warn(
-      '[updater] Safety timeout reached — skipping update check (slow/offline?).',
-    );
+    log.warn('[updater] Safety timeout (12 s) — skipping update check.');
     finish();
   }, 12_000);
 
   sendStatus('Checking for updates...', 10);
 
-  // ---------- NATIVE UPDATER ----------
+  // ==================== LAYER 2: ASAR DIFFERENTIAL ====================
+  const checkAsarUpdate = async () => {
+    sendStatus('Checking resources...', 60);
+    try {
+      const { version: remoteVersion, asarUrl } = await fetchLatestAsarInfo();
+      const localVersion = getAppVersion();
+
+      log.info(
+        `[asar-updater] Local: ${localVersion}, Remote: ${remoteVersion}, Asset: ${asarUrl ? 'yes' : 'no'}`,
+      );
+
+      if (!asarUrl || !isNewer(remoteVersion, localVersion)) {
+        log.info('[asar-updater] No ASAR update needed.');
+        sendStatus('Starting Nightwatch...', 100);
+        finish();
+        return;
+      }
+
+      // Clear safety timers — we're downloading
+      if (safetyTimer) clearTimeout(safetyTimer);
+      if (hardDeadlineTimer) clearTimeout(hardDeadlineTimer);
+
+      sendVersion(remoteVersion);
+      sendStatus('Downloading update...', 65);
+
+      // Download deadline (3 min for ~154MB gzipped)
+      hardDeadlineTimer = setTimeout(() => {
+        log.warn('[asar-updater] Download deadline (3 min) — forcing launch.');
+        finish();
+      }, 180_000);
+
+      const asarPath = path.join(path.dirname(app.getAppPath()), 'app.asar');
+      const tempPath = `${asarPath}.update`;
+
+      await downloadAndDecompress(asarUrl, tempPath, (percent) => {
+        const scaled = 65 + Math.floor(percent * 0.3); // 65% → 95%
+        sendStatus(`Downloading update... ${percent}%`, scaled);
+      });
+
+      // Swap: on Windows the running ASAR is locked, stage as .pending
+      if (process.platform === 'win32') {
+        const pendingPath = `${asarPath}.pending`;
+        fs.renameSync(tempPath, pendingPath);
+        log.info('[asar-updater] Staged for next launch (Windows).');
+      } else {
+        fs.renameSync(tempPath, asarPath);
+        log.info('[asar-updater] ASAR swapped. Restarting...');
+      }
+
+      sendStatus('Update installed — restarting...', 100);
+      setTimeout(() => {
+        app.relaunch();
+        app.exit(0);
+      }, 1500);
+    } catch (err) {
+      log.warn('[asar-updater] Failed:', err);
+      // Clean up partial download
+      try {
+        const asarPath = path.join(path.dirname(app.getAppPath()), 'app.asar');
+        fs.rmSync(`${asarPath}.update`, { force: true });
+      } catch (_e) {}
+      sendStatus('Starting Nightwatch...', 100);
+      finish();
+    }
+  };
+
+  // ==================== LAYER 1: NATIVE BINARY ====================
   autoUpdater.on('update-available', (info) => {
-    // Prevent the fast-launch timers from killing the splash screen during a large download
     if (safetyTimer) clearTimeout(safetyTimer);
     if (hardDeadlineTimer) clearTimeout(hardDeadlineTimer);
 
-    if (splashWindow && !splashWindow.isDestroyed() && info.version) {
-      splashWindow.webContents.send('updater-version', info.version);
-    }
+    sendVersion(info.version);
     sendStatus('Downloading update please...', 30);
 
-    // Without this, a stalled/slow download after clearing both timers above
-    // hangs the splash screen forever. 5 minutes is generous for any binary size.
     hardDeadlineTimer = setTimeout(
       () => {
-        log.warn(
-          '[updater] Download deadline (5 min) — forcing launch without update.',
-        );
+        log.warn('[updater] Download deadline (5 min) — forcing launch.');
         finish();
       },
       5 * 60 * 1000,
@@ -97,12 +238,10 @@ function setupUpdater(splashWindow, onComplete) {
   });
 
   autoUpdater.on('update-not-available', () => {
-    checkAsarUpdater();
+    checkAsarUpdate();
   });
 
   autoUpdater.on('update-downloaded', () => {
-    // If finish() already ran (download deadline fired), the user is already in the app.
-    // Don't interrupt their session — autoInstallOnAppQuit will handle it on next quit.
     if (updateFinished) {
       log.info(
         '[updater] Update downloaded after launch — will install on next quit.',
@@ -116,44 +255,15 @@ function setupUpdater(splashWindow, onComplete) {
   });
 
   autoUpdater.on('error', (err) => {
-    log.error('Error in auto-updater:', err);
-    checkAsarUpdater();
+    log.error('[updater] Native updater error:', err);
+    checkAsarUpdate();
   });
 
-  // ---------- ASAR HOT UPDATER ----------
-  const checkAsarUpdater = () => {
-    if (asarChecked) return;
-    asarChecked = true;
-    sendStatus('Checking resources...', 80);
-
-    try {
-      asarUpdater.setFeedURL(
-        'https://raw.githubusercontent.com/rudra-sah00/nightwatch/main/update.json',
-      );
-      asarUpdater
-        .checkForUpdates()
-        .then((res) => {
-          log.info('ASAR checked:', res);
-          sendStatus('Ready to launch!', 100);
-          finish();
-        })
-        .catch((err) => {
-          log.warn('ASAR update error/no-update:', err);
-          sendStatus('Starting Nightwatch...', 100);
-          finish();
-        });
-    } catch (err) {
-      log.warn('ASAR catch:', err);
-      sendStatus('Loading local files...', 100);
-      finish();
-    }
-  };
-
-  // Kickoff Native Updater first
   try {
     autoUpdater.checkForUpdates();
-  } catch (_e) {
-    checkAsarUpdater();
+  } catch (err) {
+    log.error('[updater] checkForUpdates threw:', err);
+    checkAsarUpdate();
   }
 }
 

--- a/electron/modules/version.js
+++ b/electron/modules/version.js
@@ -4,9 +4,8 @@ const fs = require('node:fs');
 
 /**
  * Reads the real app version from package.json inside the ASAR bundle.
- * app.getVersion() returns the native binary's compiled version, which is
- * NOT updated by electron-asar-hot-updater. This function always returns
- * the live JS bundle version.
+ * app.getVersion() returns the native binary's compiled version which
+ * may lag behind the actual bundle version.
  */
 function getAppVersion() {
   try {

--- a/electron/modules/window.js
+++ b/electron/modules/window.js
@@ -313,6 +313,7 @@ class AppWindow {
 
     this.mainWindow.on('blur', () => {
       if (isNativeFullscreen) return;
+      if (this.callActive) return;
       if (pipDebounceTimer) clearTimeout(pipDebounceTimer);
       pipDebounceTimer = setTimeout(() => {
         this.mainWindow.webContents.send('window-blur');

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -32,6 +32,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Keep screen awake while a Watch Party stream is playing (prevents lock screens!)
   setKeepAwake: (shouldKeepAwake) =>
     ipcRenderer.send('toggle-keep-awake', shouldKeepAwake),
+  setCallActive: (active) => ipcRenderer.send('set-call-active', active),
 
   // Listener to hide CSS when the Native Window shrinks down to a PiP block
   onPipModeChanged: (callback) => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -16,8 +16,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Returns the true version from package.json inside the ASAR bundle.
   // Use this instead of process.env.npm_package_version or any hardcoded value,
-  // because app.getVersion() is frozen at native binary build time and won't
-  // reflect electron-asar-hot-updater changes until a full native reinstall.
+  // because app.getVersion() is frozen at native binary build time.
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
 
   // Sync React Native Theme with Electron Window Frame

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "debug": "^4.4.3",
     "discord-rpc": "^4.0.1",
     "driver.js": "^1.4.0",
-    "electron-asar-hot-updater": "^0.1.3",
     "electron-context-menu": "^4.1.2",
     "electron-log": "^5.4.3",
     "electron-store": "8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       driver.js:
         specifier: ^1.4.0
         version: 1.4.0
-      electron-asar-hot-updater:
-        specifier: ^0.1.3
-        version: 0.1.3
       electron-context-menu:
         specifier: ^4.1.2
         version: 4.1.2
@@ -3366,10 +3363,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.4.16:
-    resolution: {integrity: sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==}
-    engines: {node: '>=0.3.0'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -3504,9 +3497,6 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
-  asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
@@ -3557,12 +3547,6 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-sign2@0.7.0:
-    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
-
-  aws4@1.13.2:
-    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
-
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
@@ -3582,9 +3566,6 @@ packages:
   baseline-browser-mapping@2.9.15:
     resolution: {integrity: sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==}
     hasBin: true
-
-  bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -3685,9 +3666,6 @@ packages:
 
   caniuse-lite@1.0.30001765:
     resolution: {integrity: sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==}
-
-  caseless@0.12.0:
-    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4156,10 +4134,6 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
-  dashdash@1.14.1:
-    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
-    engines: {node: '>=0.10'}
-
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -4329,9 +4303,6 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  ecc-jsbn@0.1.2:
-    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
-
   eciesjs@0.4.17:
     resolution: {integrity: sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -4343,9 +4314,6 @@ packages:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
     hasBin: true
-
-  electron-asar-hot-updater@0.1.3:
-    resolution: {integrity: sha512-JinLw+oQ2aoAIB1cOoFGdCMmZAB/WYLhqcxaOniwQ/eTqonHzm4MXnEJ8J19PRbX1YmtMjSxo0s4Ot6LAzBbEQ==}
 
   electron-builder-squirrel-windows@26.8.1:
     resolution: {integrity: sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==}
@@ -4366,9 +4334,6 @@ packages:
   electron-is-dev@3.0.1:
     resolution: {integrity: sha512-8TjjAh8Ec51hUi3o4TaU0mD3GMTOESi866oRNavj9A3IQJ7pmv+MJVmdZBFGw4GFT36X7bkqnuDNYvkQgvyI8Q==}
     engines: {node: '>=18'}
-
-  electron-log@4.4.8:
-    resolution: {integrity: sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA==}
 
   electron-log@5.4.3:
     resolution: {integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==}
@@ -4622,10 +4587,6 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
-  extsprintf@1.3.0:
-    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
-    engines: {'0': node >=0.6.0}
-
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
@@ -4719,13 +4680,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  forever-agent@0.6.1:
-    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
-
-  form-data@2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
-    engines: {node: '>= 0.12'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -4849,9 +4803,6 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
-  getpass@0.1.7:
-    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4913,15 +4864,6 @@ packages:
   happy-dom@20.4.0:
     resolution: {integrity: sha512-RDeQm3dT9n0A5f/TszjUmNCLEuPnMGv3Tv4BmNINebz/h17PA6LMBcxJ5FrcqltNBMh9jA/8ufgDdBYUdBt+eg==}
     engines: {node: '>=20.0.0'}
-
-  har-schema@2.0.0:
-    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
-    engines: {node: '>=4'}
-
-  har-validator@5.1.5:
-    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
-    engines: {node: '>=6'}
-    deprecated: this library is no longer supported
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -5007,10 +4949,6 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  http-signature@1.2.0:
-    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
-    engines: {node: '>=0.8', npm: '>=1.3.7'}
 
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
@@ -5290,9 +5228,6 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
-  is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
@@ -5323,9 +5258,6 @@ packages:
   isexe@3.1.5:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
-
-  isstream@0.1.2:
-    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5386,9 +5318,6 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsbn@0.1.1:
-    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
-
   jsdom@26.0.0:
     resolution: {integrity: sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==}
     engines: {node: '>=18'}
@@ -5421,9 +5350,6 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
-  json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -5437,10 +5363,6 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
-  jsprim@1.4.2:
-    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
-    engines: {node: '>=0.6.0'}
 
   katex@0.16.45:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
@@ -6154,9 +6076,6 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
-  oauth-sign@0.9.0:
-    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -6214,9 +6133,6 @@ packages:
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
-
-  original-fs@1.2.0:
-    resolution: {integrity: sha512-IGo+qFumpIV65oDchJrqL0BOk9kr82fObnTesNJt8t3YgP6vfqcmRs0ofPzg3D9PKMeBHt7lrg1k/6L+oFdS8g==}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -6349,9 +6265,6 @@ packages:
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
-  performance-now@2.1.0:
-    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -6519,9 +6432,6 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
-  psl@1.15.0:
-    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
-
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -6535,10 +6445,6 @@ packages:
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
-    engines: {node: '>=0.6'}
-
-  qs@6.5.5:
-    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -6688,14 +6594,6 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  request-progress@3.0.0:
-    resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
-
-  request@2.88.2:
-    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
-    engines: {node: '>= 6'}
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -6830,10 +6728,6 @@ packages:
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
-
-  semver-diff@3.1.1:
-    resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
-    engines: {node: '>=8'}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -7007,11 +6901,6 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
-
-  sshpk@1.18.0:
-    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
 
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
@@ -7217,9 +7106,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  throttleit@1.0.1:
-    resolution: {integrity: sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==}
-
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
@@ -7281,10 +7167,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tough-cookie@2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
-
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -7330,14 +7212,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
-
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
-
-  tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
@@ -7502,11 +7378,6 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
-  uuid@3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
@@ -7522,10 +7393,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  verror@1.10.0:
-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
-    engines: {'0': node >=0.6.0}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -11090,8 +10957,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adm-zip@0.4.16: {}
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -11252,11 +11117,8 @@ snapshots:
 
   arrify@2.0.1: {}
 
-  asn1@0.2.6:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  assert-plus@1.0.0: {}
+  assert-plus@1.0.0:
+    optional: true
 
   assert@2.1.0:
     dependencies:
@@ -11304,10 +11166,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  aws-sign2@0.7.0: {}
-
-  aws4@1.13.2: {}
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -11327,10 +11185,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.15: {}
-
-  bcrypt-pbkdf@1.0.2:
-    dependencies:
-      tweetnacl: 0.14.5
 
   bindings@1.5.0:
     dependencies:
@@ -11511,8 +11365,6 @@ snapshots:
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001765: {}
-
-  caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
@@ -11727,7 +11579,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  core-util-is@1.0.2: {}
+  core-util-is@1.0.2:
+    optional: true
 
   cors@2.8.6:
     dependencies:
@@ -11962,10 +11815,6 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
-  dashdash@1.14.1:
-    dependencies:
-      assert-plus: 1.0.0
-
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@5.0.0:
@@ -12128,11 +11977,6 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  ecc-jsbn@0.1.2:
-    dependencies:
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-
   eciesjs@0.4.17:
     dependencies:
       '@ecies/ciphers': 0.2.5(@noble/ciphers@1.3.0)
@@ -12145,15 +11989,6 @@ snapshots:
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
-
-  electron-asar-hot-updater@0.1.3:
-    dependencies:
-      adm-zip: 0.4.16
-      electron-log: 4.4.8
-      original-fs: 1.2.0
-      request: 2.88.2
-      request-progress: 3.0.0
-      semver-diff: 3.1.1
 
   electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1):
     dependencies:
@@ -12193,8 +12028,6 @@ snapshots:
       unused-filename: 4.0.1
 
   electron-is-dev@3.0.1: {}
-
-  electron-log@4.4.8: {}
 
   electron-log@5.4.3: {}
 
@@ -12536,8 +12369,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extsprintf@1.3.0: {}
-
   extsprintf@1.4.1:
     optional: true
 
@@ -12633,14 +12464,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  forever-agent@0.6.1: {}
-
-  form-data@2.3.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
 
   form-data@4.0.5:
     dependencies:
@@ -12767,10 +12590,6 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
-  getpass@0.1.7:
-    dependencies:
-      assert-plus: 1.0.0
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -12864,13 +12683,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  har-schema@2.0.0: {}
-
-  har-validator@5.1.5:
-    dependencies:
-      ajv: 6.14.0
-      har-schema: 2.0.0
 
   has-flag@4.0.0: {}
 
@@ -13007,12 +12819,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  http-signature@1.2.0:
-    dependencies:
-      assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.18.0
 
   http2-wrapper@1.0.3:
     dependencies:
@@ -13249,8 +13055,6 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
-  is-typedarray@1.0.0: {}
-
   is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@1.3.0: {}
@@ -13268,8 +13072,6 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
-
-  isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -13353,8 +13155,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsbn@0.1.1: {}
-
   jsdom@26.0.0:
     dependencies:
       cssstyle: 4.6.0
@@ -13397,9 +13197,8 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
-  json-schema@0.4.0: {}
-
-  json-stringify-safe@5.0.1: {}
+  json-stringify-safe@5.0.1:
+    optional: true
 
   json5@2.2.3: {}
 
@@ -13412,13 +13211,6 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jsprim@1.4.2:
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
 
   katex@0.16.45:
     dependencies:
@@ -14374,8 +14166,6 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  oauth-sign@0.9.0: {}
-
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -14457,8 +14247,6 @@ snapshots:
       stdin-discarder: 0.2.2
       string-width: 7.2.0
       strip-ansi: 7.1.2
-
-  original-fs@1.2.0: {}
 
   outvariant@1.4.3: {}
 
@@ -14571,8 +14359,6 @@ snapshots:
   pe-library@0.4.1: {}
 
   pend@1.2.0: {}
-
-  performance-now@2.1.0: {}
 
   pg-int8@1.0.1: {}
 
@@ -14719,10 +14505,6 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
-  psl@1.15.0:
-    dependencies:
-      punycode: 2.3.1
-
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -14737,8 +14519,6 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
-
-  qs@6.5.5: {}
 
   queue-microtask@1.2.3: {}
 
@@ -14979,33 +14759,6 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  request-progress@3.0.0:
-    dependencies:
-      throttleit: 1.0.1
-
-  request@2.88.2:
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.13.2
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      har-validator: 5.1.5
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.9.0
-      performance-now: 2.1.0
-      qs: 6.5.5
-      safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -15166,10 +14919,6 @@ snapshots:
 
   semver-compare@1.0.0:
     optional: true
-
-  semver-diff@3.1.1:
-    dependencies:
-      semver: 6.3.1
 
   semver@5.7.2: {}
 
@@ -15444,18 +15193,6 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
-  sshpk@1.18.0:
-    dependencies:
-      asn1: 0.2.6
-      assert-plus: 1.0.0
-      bcrypt-pbkdf: 1.0.2
-      dashdash: 1.14.1
-      ecc-jsbn: 0.1.2
-      getpass: 0.1.7
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-      tweetnacl: 0.14.5
-
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.3
@@ -15654,8 +15391,6 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  throttleit@1.0.1: {}
-
   throttleit@2.1.0: {}
 
   time-span@5.1.0:
@@ -15705,11 +15440,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tough-cookie@2.5.0:
-    dependencies:
-      psl: 1.15.0
-      punycode: 2.3.1
-
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -15753,13 +15483,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   tw-animate-css@1.4.0: {}
-
-  tweetnacl@0.14.5: {}
 
   type-check@0.3.2:
     dependencies:
@@ -15924,8 +15648,6 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  uuid@3.4.0: {}
-
   uuid@9.0.1: {}
 
   validate-npm-package-name@7.0.2: {}
@@ -15933,12 +15655,6 @@ snapshots:
   validator@13.15.35: {}
 
   vary@1.1.2: {}
-
-  verror@1.10.0:
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.3.0
 
   verror@1.10.1:
     dependencies:

--- a/scripts/electron-deps.js
+++ b/scripts/electron-deps.js
@@ -14,7 +14,6 @@ const ELECTRON_ENTRY_DEPS = [
   'electron-store',
   'electron-log',
   'electron-updater',
-  'electron-asar-hot-updater',
   'electron-window-state',
   'electron-context-menu',
   'discord-rpc',

--- a/scripts/prepare-electron-deps.js
+++ b/scripts/prepare-electron-deps.js
@@ -16,7 +16,6 @@ const ENTRY_DEPS = [
   'electron-store',
   'electron-log',
   'electron-updater',
-  'electron-asar-hot-updater',
   'electron-window-state',
   'electron-context-menu',
   'discord-rpc',

--- a/src/app/(public)/login/LoginClient.tsx
+++ b/src/app/(public)/login/LoginClient.tsx
@@ -75,7 +75,7 @@ export default function LoginClient() {
     <div
       className={`bg-background text-foreground h-screen h-[100dvh] flex flex-col font-body overflow-hidden transition-[transform,opacity] duration-700 ease-out origin-top motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:zoom-in-[0.99] motion-reduce:animate-none ${isTransitioning ? 'scale-[0.98] -translate-y-4 opacity-0 pointer-events-none' : 'scale-100 translate-y-0 opacity-100'}`}
     >
-      <LanguageSwitcher className="absolute top-4 right-4 z-50" />
+      <LanguageSwitcher className="absolute top-[calc(1rem+var(--electron-titlebar-height,0px))] right-[calc(1rem+var(--electron-inset-right,0px))] z-50" />
       <main className="flex-grow flex flex-col items-center p-1 md:p-2 justify-center overflow-hidden w-full max-w-[1400px] mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-2 lg:gap-4 w-full max-w-5xl items-stretch pb-2 md:pb-0 shrink-0">
           {/* Features Bento Box - Identical to Signup for Parity */}

--- a/src/app/(public)/signup/SignupClient.tsx
+++ b/src/app/(public)/signup/SignupClient.tsx
@@ -44,7 +44,7 @@ export default function SignupClient() {
     <div
       className={`bg-background text-foreground h-screen h-[100dvh] flex flex-col font-body overflow-hidden transition-[transform,opacity] duration-700 ease-out origin-top motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:zoom-in-[0.99] motion-reduce:animate-none ${isTransitioning ? 'scale-[0.98] -translate-y-4 opacity-0 pointer-events-none' : 'scale-100 translate-y-0 opacity-100'}`}
     >
-      <LanguageSwitcher className="absolute top-4 right-4 z-50" />
+      <LanguageSwitcher className="absolute top-[calc(1rem+var(--electron-titlebar-height,0px))] right-[calc(1rem+var(--electron-inset-right,0px))] z-50" />
       <main className="flex-grow flex flex-col items-center p-1 md:p-2 justify-center overflow-hidden w-full max-w-[1400px] mx-auto">
         {isInviteValid === false ? (
           <div className="flex flex-col items-center justify-center p-8 bg-background border-4 border-border  max-w-md w-full motion-safe:animate-in motion-safe:zoom-in motion-safe:duration-300 motion-reduce:animate-none">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -597,15 +597,7 @@
   /* Ensure gap-based layouts (flex gap, grid gap) work without mirroring */
   /* gap is direction-agnostic, so no override needed */
 
-  /* Electron title bar padding flips */
-  [dir="rtl"] .pl-20 {
-    padding-left: unset;
-    padding-right: 5rem;
-  }
-  [dir="rtl"] .pr-32 {
-    padding-right: unset;
-    padding-left: 8rem;
-  }
+  /* Electron title bar insets are handled via CSS variables on body */
 
   /* Hide scrollbar globally but maintain functionality */
   html,
@@ -670,6 +662,7 @@
   /* TRUE DESKTOP PIP MODE - Strip out borders and sidebars to make video strictly full bleed */
   body.is-desktop-pip {
     overflow: hidden !important;
+    padding: 0 !important;
   }
   body.is-desktop-pip header,
   body.is-desktop-pip .player-header,

--- a/src/components/layout/electron-drag-region.tsx
+++ b/src/components/layout/electron-drag-region.tsx
@@ -1,14 +1,115 @@
 'use client';
 
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useDesktopApp } from '@/hooks/use-desktop-app';
 
-export function ElectronDragRegion() {
-  const { isDesktopApp, isMounted } = useDesktopApp();
+const ROUTE_NAMES: Record<string, string> = {
+  '/home': 'Home',
+  '/login': 'Login',
+  '/signup': 'Sign Up',
+  '/profile': 'Profile',
+  '/search': 'Search',
+  '/watchlist': 'Watchlist',
+  '/live': 'Live',
+  '/downloads': 'Downloads',
+  '/whats-new': "What's New",
+  '/privacy': 'Privacy',
+  '/terms': 'Terms',
+  '/continue-watching': 'Continue Watching',
+};
 
-  // Prevent hydration mismatch by only rendering on the client after mount
+function getRouteTitle(pathname: string): string {
+  if (ROUTE_NAMES[pathname]) return ROUTE_NAMES[pathname];
+  if (pathname.startsWith('/watch-party/')) return 'Watch Party';
+  if (pathname.startsWith('/watch/')) return 'Watch';
+  if (pathname.startsWith('/live/')) return 'Live';
+  if (pathname.startsWith('/user/')) return 'Profile';
+  return 'Nightwatch';
+}
+
+export function ElectronDragRegion() {
+  const { isDesktopApp, isMounted, isMacOS, isWindows } = useDesktopApp();
+  const router = useRouter();
+  const pathname = usePathname();
+  const title = useMemo(() => getRouteTitle(pathname), [pathname]);
+
+  useEffect(() => {
+    if (!isMounted || !isDesktopApp) return;
+
+    const root = document.documentElement;
+    root.style.setProperty('--electron-titlebar-height', '32px');
+    root.style.setProperty('--electron-inset-left', isMacOS ? '140px' : '60px');
+    root.style.setProperty(
+      '--electron-inset-right',
+      isWindows ? '138px' : '0px',
+    );
+
+    return () => {
+      root.style.removeProperty('--electron-titlebar-height');
+      root.style.removeProperty('--electron-inset-left');
+      root.style.removeProperty('--electron-inset-right');
+    };
+  }, [isMounted, isDesktopApp, isMacOS, isWindows]);
+
+  const goBack = useCallback(() => router.back(), [router]);
+  const goForward = useCallback(() => router.forward(), [router]);
+
   if (!isMounted || !isDesktopApp) return null;
 
   return (
-    <div className="fixed top-0 left-0 right-0 h-8 z-[9999] bg-transparent pointer-events-auto [-webkit-app-region:drag]" />
+    <div className="fixed top-0 left-0 right-0 h-8 z-[9999] bg-background [-webkit-app-region:drag] flex items-center">
+      <div
+        className={`flex items-center gap-0.5 [-webkit-app-region:no-drag] ${isMacOS ? 'ml-[80px]' : 'ml-2'}`}
+      >
+        <button
+          type="button"
+          onClick={goBack}
+          className="w-7 h-7 flex items-center justify-center rounded-md text-foreground/40 hover:text-foreground hover:bg-foreground/10 transition-colors"
+          aria-label="Go back"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            className="stroke-current"
+          >
+            <title>Back</title>
+            <path
+              d="M10 3L5 8L10 13"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <button
+          type="button"
+          onClick={goForward}
+          className="w-7 h-7 flex items-center justify-center rounded-md text-foreground/40 hover:text-foreground hover:bg-foreground/10 transition-colors"
+          aria-label="Go forward"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            className="stroke-current"
+          >
+            <title>Forward</title>
+            <path
+              d="M6 3L11 8L6 13"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+      <span className="absolute left-1/2 -translate-x-1/2 text-[11px] font-headline font-bold uppercase tracking-[0.15em] text-foreground/70 select-none pointer-events-none">
+        {title}
+      </span>
+    </div>
   );
 }

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -4,12 +4,10 @@ import { User } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { useDesktopApp } from '@/hooks/use-desktop-app';
 import { useAuth } from '@/providers/auth-provider';
 
 export function Navbar() {
   const { user } = useAuth();
-  const { isDesktopApp, isMounted, isMacOS, isWindows } = useDesktopApp();
   const t = useTranslations('common.nav');
 
   return (
@@ -18,7 +16,11 @@ export function Navbar() {
       className={`sticky [-webkit-app-region:drag] top-0 z-50 w-full bg-background text-foreground overflow-hidden`}
     >
       <div
-        className={`flex justify-between items-center w-full max-w-5xl mx-auto px-4 sm:px-6 h-20 relative gap-4 ${isMounted && isDesktopApp && isMacOS ? 'pl-20' : ''} ${isMounted && isDesktopApp && isWindows ? 'pr-32' : ''}`}
+        className="flex justify-between items-center w-full max-w-5xl mx-auto px-4 sm:px-6 h-20 relative gap-4"
+        style={{
+          paddingLeft: `max(1rem, var(--electron-inset-left, 0px))`,
+          paddingRight: `max(1rem, var(--electron-inset-right, 0px))`,
+        }}
       >
         {/* Left Side: Brand Logo */}
         <div className="flex-1 flex justify-start items-center">

--- a/src/components/ui/creator-footer.tsx
+++ b/src/components/ui/creator-footer.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { desktopBridge, isDesktop } from '@/lib/electron-bridge';
 import pkg from '../../../package.json';
-
-const APP_VERSION = pkg.version;
 
 /**
  * Shared Creator Identity footer with social links.
@@ -12,6 +12,15 @@ const APP_VERSION = pkg.version;
  */
 export function CreatorFooter({ isCompact = false }: { isCompact?: boolean }) {
   const t = useTranslations('common');
+  const [appVersion, setAppVersion] = useState(pkg.version);
+
+  useEffect(() => {
+    if (isDesktop) {
+      desktopBridge.getAppVersion().then((v) => {
+        if (v) setAppVersion(v);
+      });
+    }
+  }, []);
 
   return (
     <div
@@ -126,7 +135,7 @@ export function CreatorFooter({ isCompact = false }: { isCompact?: boolean }) {
           href="/whats-new"
           className="font-bold border border-border px-2 py-0.5 rounded bg-muted/50 hover:bg-muted transition-colors hover:text-primary"
         >
-          v{APP_VERSION}
+          v{appVersion}
         </a>
       </div>
     </div>

--- a/src/features/friends/hooks/use-call.tsx
+++ b/src/features/friends/hooks/use-call.tsx
@@ -14,6 +14,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { desktopBridge } from '@/lib/electron-bridge';
 import { useSocket } from '@/providers/socket-provider';
 import {
   connectToAgoraCall,
@@ -146,12 +147,14 @@ export function CallProvider({ children }: { children: React.ReactNode }) {
     if (callState === 'active') {
       restoreVolumeRef.current = duckMediaElements(0.2);
       window.dispatchEvent(new CustomEvent('dm-call:start'));
+      desktopBridge.setCallActive(true);
     }
     return () => {
       if (restoreVolumeRef.current) {
         restoreVolumeRef.current();
         restoreVolumeRef.current = null;
       }
+      desktopBridge.setCallActive(false);
     };
   }, [callState]);
 

--- a/src/lib/electron-bridge.ts
+++ b/src/lib/electron-bridge.ts
@@ -70,6 +70,7 @@ function createBridge() {
       setPictureInPicture: noop as (e: boolean, o?: number) => void,
       setUnreadBadge: noop as (c: number) => void,
       setKeepAwake: noop as (k: boolean) => void,
+      setCallActive: noop as (active: boolean) => void,
       onPipModeChanged: noopListen as (
         cb: (isPip: boolean) => void,
       ) => UnlistenFn,
@@ -130,6 +131,7 @@ function createBridge() {
       e.setPictureInPicture(enabled, opacity),
     setUnreadBadge: (c: number) => e.setUnreadBadge(c),
     setKeepAwake: (k: boolean) => e.setKeepAwake(k),
+    setCallActive: (active: boolean) => e.setCallActive(active),
     onPipModeChanged: (cb: (isPip: boolean) => void) =>
       e.onPipModeChanged(cb) as UnlistenFn,
     showNotification: (p: {

--- a/update.json
+++ b/update.json
@@ -1,5 +1,0 @@
-{
-  "version": "2.1.5",
-  "notes": "Latest ASAR bundle update",
-  "url": "https://github.com/rudra-sah00/nightwatch/releases/download/v2.1.5/app.asar"
-}


### PR DESCRIPTION
## Problem
Three bugs in the desktop app:
1. Splash screen showed v2.1.5 (stale ASAR from broken hot-updater)
2. About panel showed v2.4.0 (native binary compile-time version)
3. Every launch downloaded the full 292MB update but never installed it (safety timer race + ASAR updater interference)

## Root Cause
`electron-asar-hot-updater` with a manually-maintained `update.json` stuck at v2.1.5. The updater's 12s safety timer fired before the native download completed, then the ASAR fallback interfered with the install.

## Solution
Two-layer update system (similar to Discord):

**Layer 1 — Native binary** (`electron-updater`): Full .dmg/.exe/.AppImage for Electron version bumps. Rare, large downloads.

**Layer 2 — ASAR differential** (new): For code-only changes. Queries GitHub Releases API dynamically (no hardcoded versions), downloads gzipped ASAR (~154MB vs 292MB full DMG), streaming decompress, atomic swap.

## Changes (10 files)
- Remove `electron-asar-hot-updater` (dependency + all references + `update.json`)
- New two-layer updater with `net.fetch()` + zlib streaming pipeline
- CI: auto-extract, gzip, and upload `app.asar.gz` to GitHub Releases
- Windows: staged `.pending` swap on next launch (file lock workaround)
- Fix `creator-footer.tsx` to use IPC version in Electron

## Verified Locally
| Test | Result |
|---|---|
| CI gzip step | ✅ 584MB → 154MB, integrity valid |
| GitHub API + version compare | ✅ 6/6 semver cases, correct structure |
| Download + gunzip pipeline | ✅ 0.9s decompress, byte-for-byte match |
| ASAR swap (rename) | ✅ Atomic, valid 34563-file ASAR |
| Windows pending swap | ✅ .pending detect + rename |
| Packaged app boot | ✅ Runs with swapped ASAR |

## E2E Testing Needed
Requires a real release cycle: push → release v2.5.1 → install v2.5.0 → verify ASAR differential download + swap + relaunch