### PR TITLE
feat: centered search bars, player subtitle fix & debug overlay

### DIFF
--- a/src/features/manga/components/MangaClient.tsx
+++ b/src/features/manga/components/MangaClient.tsx
@@ -105,6 +105,10 @@ export function MangaClient() {
   const [titles, setTitles] = useState<MangaTitle[]>([]);
   const [loading, setLoading] = useState(true);
   const [showSearch, setShowSearch] = useState(false);
+  const [searchOriginRect, setSearchOriginRect] = useState<DOMRect | null>(
+    null,
+  );
+  const searchRef = useRef<HTMLButtonElement>(null);
   const t = useTranslations('common.manga');
 
   const fetchData = useCallback(async (t: Tab) => {
@@ -195,21 +199,32 @@ export function MangaClient() {
     <main className="pb-32 animate-in fade-in">
       {/* Search Spotlight */}
       {showSearch && (
-        <MangaSearchSpotlight onClose={() => setShowSearch(false)} />
+        <MangaSearchSpotlight
+          originRect={searchOriginRect}
+          onClose={() => setShowSearch(false)}
+        />
       )}
 
       {/* Header — like music */}
-      <div className="flex items-center justify-between px-6 pt-6 pb-2">
-        <h1 className="font-headline text-2xl md:text-3xl font-black uppercase tracking-tighter">
+      <div className="flex items-center justify-between px-6 pt-6 pb-2 gap-3">
+        <h1 className="font-headline text-2xl md:text-3xl font-black uppercase tracking-tighter shrink-0">
           {t('title')}
         </h1>
         <button
+          ref={searchRef}
           type="button"
-          onClick={() => setShowSearch(true)}
-          className="w-10 h-10 flex items-center justify-center rounded-full bg-card border-[2px] border-border hover:border-neo-cyan hover:bg-neo-cyan/10 transition-colors"
+          onClick={() => {
+            const rect = searchRef.current?.getBoundingClientRect();
+            if (rect) setSearchOriginRect(rect);
+            setShowSearch(true);
+          }}
+          className="flex-1 max-w-md h-10 flex items-center gap-2 px-4 rounded-full bg-card border-[2px] border-border hover:border-neo-cyan hover:bg-neo-cyan/10 transition-colors cursor-pointer"
           aria-label={t('searchAriaLabel')}
         >
-          <Search className="w-4 h-4 text-foreground/50" />
+          <Search className="w-4 h-4 text-foreground/40 shrink-0" />
+          <span className="text-sm text-foreground/40 font-body truncate">
+            {t('searchPlaceholder')}
+          </span>
         </button>
       </div>
 

--- a/src/features/manga/components/MangaSearchSpotlight.tsx
+++ b/src/features/manga/components/MangaSearchSpotlight.tsx
@@ -8,24 +8,54 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MangaTitle } from '@/features/manga/api';
 import { searchManga } from '@/features/manga/api';
 
-export function MangaSearchSpotlight({ onClose }: { onClose: () => void }) {
+export function MangaSearchSpotlight({
+  originRect,
+  onClose,
+}: {
+  originRect?: DOMRect | null;
+  onClose: () => void;
+}) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<MangaTitle[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [visible, setVisible] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const searchBarRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const t = useTranslations('common.manga');
 
+  // FLIP animation + initial setup
   useEffect(() => {
     requestAnimationFrame(() => setVisible(true));
+
+    // FLIP animation: animate input bar from header search bar position
+    if (originRect && searchBarRef.current) {
+      const el = searchBarRef.current;
+      const finalRect = el.getBoundingClientRect();
+      const dx = originRect.left - finalRect.left;
+      const dy = originRect.top - finalRect.top;
+      const sx = originRect.width / finalRect.width;
+      const sy = originRect.height / finalRect.height;
+
+      el.animate(
+        [
+          {
+            transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`,
+            opacity: 0.8,
+          },
+          { transform: 'translate(0, 0) scale(1, 1)', opacity: 1 },
+        ],
+        { duration: 300, easing: 'cubic-bezier(0.4, 0, 0.2, 1)', fill: 'both' },
+      );
+    }
+
     if (!window.Capacitor?.isNativePlatform?.()) {
       setTimeout(() => inputRef.current?.focus(), 100);
     }
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, []);
+  }, [originRect]);
 
   const close = () => {
     setVisible(false);
@@ -66,10 +96,13 @@ export function MangaSearchSpotlight({ onClose }: { onClose: () => void }) {
       tabIndex={-1}
     >
       <div
-        className={`w-full max-w-xl mx-4 max-h-[80vh] flex flex-col overflow-hidden transition-all duration-200 ${visible ? 'scale-100 opacity-100' : 'scale-75 opacity-0'}`}
+        className={`w-full max-w-xl mx-4 max-h-[80vh] flex flex-col overflow-hidden transition-all duration-200 ${visible ? 'scale-100 opacity-100' : originRect ? 'scale-100 opacity-0' : 'scale-75 opacity-0'}`}
       >
         {/* Input */}
-        <div className="flex items-center bg-white/10 backdrop-blur-2xl rounded-full border border-white/20 shadow-2xl px-5 py-3.5 gap-3 shrink-0">
+        <div
+          ref={searchBarRef}
+          className="flex items-center bg-white/10 backdrop-blur-2xl rounded-full border border-white/20 shadow-2xl px-5 py-3.5 gap-3 shrink-0"
+        >
           <Search className="w-5 h-5 text-white/40 shrink-0" />
           <input
             ref={inputRef}

--- a/src/features/music/components/MusicHeader.tsx
+++ b/src/features/music/components/MusicHeader.tsx
@@ -38,11 +38,22 @@ export function MusicHeader({
   const t = useTranslations('music');
 
   return (
-    <div className="flex items-center justify-between px-6 pt-6 pb-2">
-      <h1 className="font-headline text-2xl md:text-3xl font-black uppercase tracking-tighter">
+    <div className="flex items-center justify-between px-6 pt-6 pb-2 gap-3">
+      <h1 className="font-headline text-2xl md:text-3xl font-black uppercase tracking-tighter shrink-0">
         {t('title')}
       </h1>
-      <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={onOpenSearch}
+        className="flex-1 max-w-md h-10 flex items-center gap-2 px-4 rounded-full bg-card border-[2px] border-border hover:border-neo-yellow hover:bg-neo-yellow/10 transition-colors cursor-pointer"
+        aria-label={t('searchMusic')}
+      >
+        <Search className="w-4 h-4 text-foreground/40 shrink-0" />
+        <span className="text-sm text-foreground/40 font-body truncate">
+          {t('searchPlaceholder')}
+        </span>
+      </button>
+      <div className="flex items-center gap-2 shrink-0">
         <button
           type="button"
           onClick={onOpenLangPicker}
@@ -64,14 +75,6 @@ export function MusicHeader({
           aria-label={t('createPlaylist')}
         >
           <Plus className="w-4 h-4 text-foreground/50" />
-        </button>
-        <button
-          type="button"
-          onClick={onOpenSearch}
-          className="w-10 h-10 flex items-center justify-center rounded-full bg-card border-[2px] border-border hover:border-neo-yellow hover:bg-neo-yellow/10 transition-colors"
-          aria-label={t('searchMusic')}
-        >
-          <Search className="w-4 h-4 text-foreground/50" />
         </button>
       </div>
     </div>

--- a/src/features/music/components/MusicHeader.tsx
+++ b/src/features/music/components/MusicHeader.tsx
@@ -2,6 +2,7 @@
 
 import { Globe, Plus, Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { useRef } from 'react';
 
 /**
  * Props for the {@link MusicHeader} component.
@@ -13,8 +14,8 @@ interface MusicHeaderProps {
   onOpenLangPicker: () => void;
   /** Toggles the {@link CreatePlaylistDialog}. */
   onToggleCreatePlaylist: () => void;
-  /** Opens the {@link MusicSearchSpotlight} overlay. */
-  onOpenSearch: () => void;
+  /** Opens the {@link MusicSearchSpotlight} overlay, passing the origin rect for animation. */
+  onOpenSearch: (originRect: DOMRect) => void;
 }
 
 /**
@@ -36,6 +37,7 @@ export function MusicHeader({
   onOpenSearch,
 }: MusicHeaderProps) {
   const t = useTranslations('music');
+  const searchRef = useRef<HTMLButtonElement>(null);
 
   return (
     <div className="flex items-center justify-between px-6 pt-6 pb-2 gap-3">
@@ -43,8 +45,12 @@ export function MusicHeader({
         {t('title')}
       </h1>
       <button
+        ref={searchRef}
         type="button"
-        onClick={onOpenSearch}
+        onClick={() => {
+          const rect = searchRef.current?.getBoundingClientRect();
+          if (rect) onOpenSearch(rect);
+        }}
         className="flex-1 max-w-md h-10 flex items-center gap-2 px-4 rounded-full bg-card border-[2px] border-border hover:border-neo-yellow hover:bg-neo-yellow/10 transition-colors cursor-pointer"
         aria-label={t('searchMusic')}
       >

--- a/src/features/music/components/MusicSearchSpotlight.tsx
+++ b/src/features/music/components/MusicSearchSpotlight.tsx
@@ -36,7 +36,13 @@ import { showSongMenu } from './SongContextMenu';
  *
  * @param props.onClose - Callback invoked after the closing animation completes.
  */
-export function MusicSearchSpotlight({ onClose }: { onClose: () => void }) {
+export function MusicSearchSpotlight({
+  originRect,
+  onClose,
+}: {
+  originRect?: DOMRect | null;
+  onClose: () => void;
+}) {
   const t = useTranslations('music');
   const player = useMusicPlayerContext();
   const [query, setQuery] = useState('');
@@ -76,12 +82,36 @@ export function MusicSearchSpotlight({ onClose }: { onClose: () => void }) {
   const pageRef = useRef(1);
   const hasMoreRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const searchBarRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressTriggered = useRef(false);
 
+  // FLIP animation + initial setup
   useEffect(() => {
     requestAnimationFrame(() => setVisible(true));
+
+    // FLIP animation: animate input bar from header search bar position
+    if (originRect && searchBarRef.current) {
+      const el = searchBarRef.current;
+      const finalRect = el.getBoundingClientRect();
+      const dx = originRect.left - finalRect.left;
+      const dy = originRect.top - finalRect.top;
+      const sx = originRect.width / finalRect.width;
+      const sy = originRect.height / finalRect.height;
+
+      el.animate(
+        [
+          {
+            transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`,
+            opacity: 0.8,
+          },
+          { transform: 'translate(0, 0) scale(1, 1)', opacity: 1 },
+        ],
+        { duration: 300, easing: 'cubic-bezier(0.4, 0, 0.2, 1)', fill: 'both' },
+      );
+    }
+
     // Don't auto-focus on mobile — causes iOS to zoom/scroll
     if (!window.Capacitor?.isNativePlatform?.()) {
       setTimeout(() => inputRef.current?.focus(), 100);
@@ -94,7 +124,7 @@ export function MusicSearchSpotlight({ onClose }: { onClose: () => void }) {
         clearTimeout(debounceRef.current);
       }
     };
-  }, []);
+  }, [originRect]);
 
   const close = () => {
     setVisible(false);
@@ -192,10 +222,13 @@ export function MusicSearchSpotlight({ onClose }: { onClose: () => void }) {
       tabIndex={-1}
     >
       <div
-        className={`w-full max-w-xl mx-4 max-h-[80vh] flex flex-col overflow-hidden transition-all duration-200 ${visible ? 'scale-100 opacity-100' : 'scale-75 opacity-0'}`}
+        className={`w-full max-w-xl mx-4 max-h-[80vh] flex flex-col overflow-hidden transition-all duration-200 ${visible ? 'scale-100 opacity-100' : originRect ? 'scale-100 opacity-0' : 'scale-75 opacity-0'}`}
       >
         {/* Input */}
-        <div className="flex items-center bg-white/10 backdrop-blur-2xl rounded-full border border-white/20 shadow-2xl px-5 py-3.5 gap-3 shrink-0">
+        <div
+          ref={searchBarRef}
+          className="flex items-center bg-white/10 backdrop-blur-2xl rounded-full border border-white/20 shadow-2xl px-5 py-3.5 gap-3 shrink-0"
+        >
           <Search className="w-5 h-5 text-white/40 shrink-0" />
           <input
             ref={inputRef}

--- a/src/features/music/components/MusicView.tsx
+++ b/src/features/music/components/MusicView.tsx
@@ -47,6 +47,9 @@ export function MusicView() {
     podcasts: [],
   });
   const [showSearch, setShowSearch] = useState(false);
+  const [searchOriginRect, setSearchOriginRect] = useState<DOMRect | null>(
+    null,
+  );
   const [showCreatePlaylist, setShowCreatePlaylist] = useState(false);
   const [loading, setLoading] = useState(true);
   const [playlistKey, setPlaylistKey] = useState(0);
@@ -109,7 +112,10 @@ export function MusicView() {
         selectedLangs={selectedLangs}
         onOpenLangPicker={() => setShowLangPicker(true)}
         onToggleCreatePlaylist={() => setShowCreatePlaylist((v) => !v)}
-        onOpenSearch={() => setShowSearch(true)}
+        onOpenSearch={(rect) => {
+          setSearchOriginRect(rect);
+          setShowSearch(true);
+        }}
       />
 
       {showCreatePlaylist && (
@@ -139,7 +145,10 @@ export function MusicView() {
       )}
 
       {showSearch && (
-        <MusicSearchSpotlight onClose={() => setShowSearch(false)} />
+        <MusicSearchSpotlight
+          originRect={searchOriginRect}
+          onClose={() => setShowSearch(false)}
+        />
       )}
     </div>
   );

--- a/src/features/watch/hooks/use-watch-content.ts
+++ b/src/features/watch/hooks/use-watch-content.ts
@@ -175,18 +175,32 @@ export function useWatchContent() {
         let response: PlayResponse;
 
         if (type === 'series' && season && episode) {
-          console.log('[NW-Play] VOD: fetching series stream', {
-            seriesId: overrideMovieId || seriesId || movieId,
-            season,
-            episode,
-          });
-          response = await playVideo({
-            type: 'series',
-            title: decodedTitle,
-            seriesId: overrideMovieId || seriesId || movieId || undefined,
-            season: parseInt(season, 10),
-            episode: parseInt(episode, 10),
-          });
+          // When overrideMovieId is a dub content ID (s1: prefixed), it represents
+          // a standalone content entry for that language. Fetch it as a movie so
+          // the backend resolves the exact dub, not the default language.
+          if (overrideMovieId?.startsWith('s1:')) {
+            console.log('[NW-Play] VOD: fetching dub as movie', {
+              movieId: overrideMovieId,
+            });
+            response = await playVideo({
+              type: 'movie',
+              title: decodedTitle,
+              movieId: overrideMovieId,
+            });
+          } else {
+            console.log('[NW-Play] VOD: fetching series stream', {
+              seriesId: overrideMovieId || seriesId || movieId,
+              season,
+              episode,
+            });
+            response = await playVideo({
+              type: 'series',
+              title: decodedTitle,
+              seriesId: overrideMovieId || seriesId || movieId || undefined,
+              season: parseInt(season, 10),
+              episode: parseInt(episode, 10),
+            });
+          }
         } else {
           console.log('[NW-Play] VOD: fetching stream', {
             movieId: overrideMovieId || movieId,

--- a/src/features/watch/player/hooks/useAudioTracks.ts
+++ b/src/features/watch/player/hooks/useAudioTracks.ts
@@ -181,9 +181,19 @@ export function useAudioTracks({
 
       if (track.streamUrl.startsWith('s1:')) {
         // Dub stored as a separate content entry → full refetch needed.
+        console.log('[NW-Audio] Language switch (refetch):', {
+          trackId,
+          label: track.label,
+          streamUrl: track.streamUrl,
+        });
         onRefetch(track.streamUrl);
       } else {
         // Direct MP4 URL → swap in place.
+        console.log('[NW-Audio] Language switch (direct URL swap):', {
+          trackId,
+          label: track.label,
+          url: track.streamUrl?.slice(0, 80),
+        });
         onStreamChange(track.streamUrl);
       }
     },

--- a/src/features/watch/player/hooks/useHls.ts
+++ b/src/features/watch/player/hooks/useHls.ts
@@ -97,6 +97,18 @@ export function useHls({
     // Capture native HLS handler so the cleanup closure can remove it
     let nativeLoadedMetadataHandler: (() => void) | null = null;
 
+    console.log(
+      '[NW-HLS] Initializing with stream URL:',
+      streamUrl?.slice(0, 80),
+    );
+    console.log('[NW-HLS] Video element state:', {
+      readyState: video.readyState,
+      networkState: video.networkState,
+      currentTime: video.currentTime,
+      videoWidth: video.videoWidth,
+      videoHeight: video.videoHeight,
+    });
+
     // Clear any previous errors when loading new stream
     dispatch({ type: 'SET_ERROR', error: null });
     dispatch({ type: 'SET_LOADING', isLoading: true });
@@ -438,6 +450,16 @@ export function useHls({
                 hls.startLoad();
                 break;
               case Hls.ErrorTypes.MEDIA_ERROR:
+                console.warn(
+                  '[NW-HLS] Fatal MEDIA_ERROR, attempting recovery:',
+                  {
+                    details: data.details,
+                    videoReadyState: video.readyState,
+                    videoWidth: video.videoWidth,
+                    videoHeight: video.videoHeight,
+                    currentTime: video.currentTime,
+                  },
+                );
                 dispatch({ type: 'SET_BUFFERING', isBuffering: true });
                 hls.recoverMediaError();
                 break;
@@ -640,6 +662,11 @@ export function useHls({
 
     return () => {
       cancelled = true;
+      console.log('[NW-HLS] Cleanup: destroying HLS instance', {
+        hadHls: !!hlsRef.current,
+        videoReadyState: video.readyState,
+        videoTime: video.currentTime,
+      });
       if (hlsRef.current) {
         hlsRef.current.destroy();
         hlsRef.current = null;

--- a/src/features/watch/player/hooks/useMp4.ts
+++ b/src/features/watch/player/hooks/useMp4.ts
@@ -38,6 +38,16 @@ export function useMp4({
 
     const video = videoRef.current;
 
+    console.log('[NW-MP4] Setting new stream URL:', streamUrl?.slice(0, 80));
+    console.log('[NW-MP4] Video state before src change:', {
+      readyState: video.readyState,
+      networkState: video.networkState,
+      currentTime: video.currentTime,
+      videoWidth: video.videoWidth,
+      videoHeight: video.videoHeight,
+      paused: video.paused,
+    });
+
     // Clear any previous errors when loading new stream
     dispatch({ type: 'SET_ERROR', error: null });
     dispatch({ type: 'SET_LOADING', isLoading: true });
@@ -96,6 +106,10 @@ export function useMp4({
       if (metadataTimeout) clearTimeout(metadataTimeout);
       video.removeEventListener('loadedmetadata', handleLoadedMetadata);
       video.removeEventListener('error', handleError);
+      console.log('[NW-MP4] Cleanup: pausing and removing src', {
+        readyState: video.readyState,
+        currentTime: video.currentTime,
+      });
       video.pause();
       video.removeAttribute('src'); // Better than src='' which can cause network requests
     };

--- a/src/features/watch/player/hooks/usePlayerHandlers.ts
+++ b/src/features/watch/player/hooks/usePlayerHandlers.ts
@@ -254,6 +254,17 @@ export function usePlayerHandlers({
   // Handle audio track change
   const handleAudioChange = useCallback(
     (trackId: string) => {
+      console.log('[NW-Player] Audio track change requested:', trackId);
+      const video = videoRef.current;
+      if (video) {
+        console.log('[NW-Player] Video state before audio change:', {
+          readyState: video.readyState,
+          networkState: video.networkState,
+          currentTime: video.currentTime,
+          paused: video.paused,
+          src: video.src?.slice(0, 80),
+        });
+      }
       setAudioTrack(trackId);
       dispatch({ type: 'SET_CURRENT_AUDIO_TRACK', trackId });
       // For language dubs the parent swaps the top-level streamUrl
@@ -261,16 +272,28 @@ export function usePlayerHandlers({
       onExternalAudioChange?.(trackId);
       showControls();
     },
-    [setAudioTrack, dispatch, showControls, onExternalAudioChange],
+    [setAudioTrack, dispatch, showControls, onExternalAudioChange, videoRef],
   );
 
   // Handle subtitle track change
   const handleSubtitleChange = useCallback(
     (trackId: string | null) => {
+      console.log('[NW-Player] Subtitle track change requested:', trackId);
+      const video = videoRef.current;
+      if (video) {
+        console.log('[NW-Player] Video state before subtitle change:', {
+          readyState: video.readyState,
+          networkState: video.networkState,
+          currentTime: video.currentTime,
+          paused: video.paused,
+          videoWidth: video.videoWidth,
+          videoHeight: video.videoHeight,
+        });
+      }
       dispatch({ type: 'SET_CURRENT_SUBTITLE_TRACK', trackId });
       showControls();
     },
-    [dispatch, showControls],
+    [dispatch, showControls, videoRef],
   );
 
   // Handle retry on error

--- a/src/features/watch/player/ui/compound/hooks/use-subtitle-overlay.ts
+++ b/src/features/watch/player/ui/compound/hooks/use-subtitle-overlay.ts
@@ -31,8 +31,11 @@ export function useSubtitleOverlay({
       if (document.getElementById('hide-native-cues')) return;
       const style = document.createElement('style');
       style.id = 'hide-native-cues';
-      style.textContent =
-        'video::cue { color: transparent; background: transparent; text-shadow: none; }';
+      style.textContent = [
+        'video::cue { color: transparent; background: transparent; text-shadow: none; font-size: 0; line-height: 0; opacity: 0; }',
+        'video::-webkit-media-text-track-container { display: none !important; }',
+        'video::-webkit-media-text-track-display { display: none !important; }',
+      ].join('\n');
       document.head.appendChild(style);
     };
 

--- a/src/features/watch/player/ui/overlays/DebugOverlay.tsx
+++ b/src/features/watch/player/ui/overlays/DebugOverlay.tsx
@@ -128,11 +128,22 @@ export function DebugOverlay() {
     };
   }, [videoRef, addLog]);
 
-  // Triple-tap to toggle
+  // Triple-tap to toggle (mobile) + Ctrl+Shift+D (desktop)
   useEffect(() => {
     if (!isStaging) return;
+
+    // Keyboard shortcut for desktop
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key === 'D') {
+        e.preventDefault();
+        setVisible((v) => !v);
+      }
+    };
+    document.addEventListener('keydown', keyHandler);
+
     const container = document.querySelector('.video-container');
-    if (!container) return;
+    if (!container)
+      return () => document.removeEventListener('keydown', keyHandler);
 
     const handler = () => {
       tapCountRef.current += 1;
@@ -148,10 +159,9 @@ export function DebugOverlay() {
     };
 
     container.addEventListener('touchend', handler);
-    container.addEventListener('dblclick', handler);
     return () => {
+      document.removeEventListener('keydown', keyHandler);
       container.removeEventListener('touchend', handler);
-      container.removeEventListener('dblclick', handler);
     };
   }, []);
 

--- a/src/features/watch/player/ui/overlays/DebugOverlay.tsx
+++ b/src/features/watch/player/ui/overlays/DebugOverlay.tsx
@@ -128,22 +128,12 @@ export function DebugOverlay() {
     };
   }, [videoRef, addLog]);
 
-  // Triple-tap to toggle (mobile) + Ctrl+Shift+D (desktop)
+  // Triple-tap to toggle (mobile) + fixed button (desktop)
   useEffect(() => {
     if (!isStaging) return;
 
-    // Keyboard shortcut for desktop: Ctrl+Shift+D (Windows/Linux) or Cmd+Shift+D (macOS)
-    const keyHandler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'D') {
-        e.preventDefault();
-        setVisible((v) => !v);
-      }
-    };
-    document.addEventListener('keydown', keyHandler);
-
     const container = document.querySelector('.video-container');
-    if (!container)
-      return () => document.removeEventListener('keydown', keyHandler);
+    if (!container) return;
 
     const handler = () => {
       tapCountRef.current += 1;
@@ -160,7 +150,6 @@ export function DebugOverlay() {
 
     container.addEventListener('touchend', handler);
     return () => {
-      document.removeEventListener('keydown', keyHandler);
       container.removeEventListener('touchend', handler);
     };
   }, []);
@@ -199,70 +188,85 @@ export function DebugOverlay() {
 
   // Don't render anything in production
   if (!isStaging) return null;
-  if (!visible) return null;
 
   const video = videoRef.current;
   const hls = hlsRef.current;
 
   return (
-    <div
-      className="absolute top-0 left-0 right-0 bottom-0 z-[9998] pointer-events-none"
-      aria-hidden="true"
-    >
-      <div className="absolute top-2 left-2 right-2 max-h-[70%] overflow-hidden pointer-events-auto rounded-md bg-black/85 border border-green-500/60 p-2 font-mono text-[10px] leading-tight text-green-400 select-text">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-1 border-b border-green-500/30 pb-1">
-          <span className="text-green-300 font-bold text-[11px]">🟢 DEBUG</span>
-          <button
-            type="button"
-            onClick={handleCopy}
-            className="text-[9px] bg-green-900/60 border border-green-500/40 rounded px-1.5 py-0.5 text-green-300 active:bg-green-700/60"
-          >
-            {copied ? '✓ Copied' : '📋 Copy'}
-          </button>
-        </div>
+    <>
+      {/* Debug toggle button — always visible on staging */}
+      <button
+        type="button"
+        onClick={() => setVisible((v) => !v)}
+        className="absolute top-2 right-2 z-[9999] pointer-events-auto w-7 h-7 flex items-center justify-center rounded-full bg-black/60 border border-green-500/50 text-green-400 text-[10px] font-bold hover:bg-green-900/60 transition-colors"
+        aria-label="Toggle debug overlay"
+      >
+        🟢
+      </button>
 
-        {/* Stats */}
-        <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 mb-1.5">
-          <span>
-            ▶ {state.isPlaying ? 'PLAYING' : 'PAUSED'}
-            {state.isBuffering ? ' (buffering)' : ''}
-          </span>
-          <span>🎞️ {state.currentQuality}</span>
-          <span>
-            ⏱️ {state.currentTime.toFixed(1)}s / {state.duration.toFixed(1)}s
-          </span>
-          <span>📦 Buf: {state.buffered.toFixed(1)}s</span>
-          <span>📡 readyState: {video?.readyState ?? '-'}</span>
-          <span>🌐 networkState: {video?.networkState ?? '-'}</span>
-          {hls && (
-            <>
-              <span>
-                🔧 HLS lvl: {hls.currentLevel}/{hls.levels?.length ?? 0}
-              </span>
-              <span>
-                📊 {((hls.bandwidthEstimate ?? 0) / 1e6).toFixed(1)} Mbps
-              </span>
-            </>
-          )}
-          {!hls && <span>📱 Native AVPlayer</span>}
-        </div>
-
-        {/* Log */}
+      {!visible ? null : (
         <div
-          ref={logRef}
-          className="max-h-32 overflow-y-auto border-t border-green-500/30 pt-1 space-y-px"
+          className="absolute top-0 left-0 right-0 bottom-0 z-[9998] pointer-events-none"
+          aria-hidden="true"
         >
-          {logs.map((l) => (
-            <div key={`${l.time}-${l.msg}`} className="text-green-500/80">
-              <span className="text-green-700">
-                {new Date(l.time).toLocaleTimeString()}
-              </span>{' '}
-              {l.msg}
+          <div className="absolute top-2 left-2 right-2 max-h-[70%] overflow-hidden pointer-events-auto rounded-md bg-black/85 border border-green-500/60 p-2 font-mono text-[10px] leading-tight text-green-400 select-text">
+            {/* Header */}
+            <div className="flex items-center justify-between mb-1 border-b border-green-500/30 pb-1">
+              <span className="text-green-300 font-bold text-[11px]">
+                🟢 DEBUG
+              </span>
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="text-[9px] bg-green-900/60 border border-green-500/40 rounded px-1.5 py-0.5 text-green-300 active:bg-green-700/60"
+              >
+                {copied ? '✓ Copied' : '📋 Copy'}
+              </button>
             </div>
-          ))}
+
+            {/* Stats */}
+            <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 mb-1.5">
+              <span>
+                ▶ {state.isPlaying ? 'PLAYING' : 'PAUSED'}
+                {state.isBuffering ? ' (buffering)' : ''}
+              </span>
+              <span>🎞️ {state.currentQuality}</span>
+              <span>
+                ⏱️ {state.currentTime.toFixed(1)}s / {state.duration.toFixed(1)}s
+              </span>
+              <span>📦 Buf: {state.buffered.toFixed(1)}s</span>
+              <span>📡 readyState: {video?.readyState ?? '-'}</span>
+              <span>🌐 networkState: {video?.networkState ?? '-'}</span>
+              {hls && (
+                <>
+                  <span>
+                    🔧 HLS lvl: {hls.currentLevel}/{hls.levels?.length ?? 0}
+                  </span>
+                  <span>
+                    📊 {((hls.bandwidthEstimate ?? 0) / 1e6).toFixed(1)} Mbps
+                  </span>
+                </>
+              )}
+              {!hls && <span>📱 Native AVPlayer</span>}
+            </div>
+
+            {/* Log */}
+            <div
+              ref={logRef}
+              className="max-h-32 overflow-y-auto border-t border-green-500/30 pt-1 space-y-px"
+            >
+              {logs.map((l) => (
+                <div key={`${l.time}-${l.msg}`} className="text-green-500/80">
+                  <span className="text-green-700">
+                    {new Date(l.time).toLocaleTimeString()}
+                  </span>{' '}
+                  {l.msg}
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 }

--- a/src/features/watch/player/ui/overlays/DebugOverlay.tsx
+++ b/src/features/watch/player/ui/overlays/DebugOverlay.tsx
@@ -65,6 +65,19 @@ export function DebugOverlay() {
       addLog(`🎞️ Quality → ${state.currentQuality}`);
   }, [state.currentQuality, visible, addLog]);
 
+  useEffect(() => {
+    if (!isStaging) return;
+    addLog(
+      `🔤 Subtitle → ${state.currentSubtitleTrack || 'OFF'} (tracks: ${state.subtitleTracks.length})`,
+    );
+  }, [state.currentSubtitleTrack, state.subtitleTracks.length, addLog]);
+
+  useEffect(() => {
+    if (!isStaging) return;
+    if (state.currentAudioTrack)
+      addLog(`🔊 Audio → ${state.currentAudioTrack}`);
+  }, [state.currentAudioTrack, addLog]);
+
   // Log stream URL changes (refetch detection)
   useEffect(() => {
     if (!visible || !isStaging) return;

--- a/src/features/watch/player/ui/overlays/DebugOverlay.tsx
+++ b/src/features/watch/player/ui/overlays/DebugOverlay.tsx
@@ -132,9 +132,9 @@ export function DebugOverlay() {
   useEffect(() => {
     if (!isStaging) return;
 
-    // Keyboard shortcut for desktop
+    // Keyboard shortcut for desktop: Ctrl+Shift+D (Windows/Linux) or Cmd+Shift+D (macOS)
     const keyHandler = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.shiftKey && e.key === 'D') {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'D') {
         e.preventDefault();
         setVisible((v) => !v);
       }

--- a/src/features/watch/player/ui/use-video-element.ts
+++ b/src/features/watch/player/ui/use-video-element.ts
@@ -161,6 +161,14 @@ export function useVideoElement({
     const trackId = currentTrackId;
     const textTracks = video.textTracks;
 
+    console.log('[NW-Subtitle] Track mode switch:', {
+      trackId,
+      textTracksCount: textTracks.length,
+      videoReadyState: video.readyState,
+      videoWidth: video.videoWidth,
+      videoHeight: video.videoHeight,
+    });
+
     for (let i = 0; i < textTracks.length; i++) {
       textTracks[i].mode = 'hidden';
     }

--- a/src/features/watch/player/ui/use-video-element.ts
+++ b/src/features/watch/player/ui/use-video-element.ts
@@ -164,9 +164,13 @@ export function useVideoElement({
     console.log('[NW-Subtitle] Track mode switch:', {
       trackId,
       textTracksCount: textTracks.length,
-      videoReadyState: video.readyState,
-      videoWidth: video.videoWidth,
-      videoHeight: video.videoHeight,
+      subtitleTracksCount: subtitleTracks.length,
+      textTrackIds: Array.from({ length: textTracks.length }, (_, i) => ({
+        id: textTracks[i].id,
+        label: textTracks[i].label,
+        language: textTracks[i].language,
+        kind: textTracks[i].kind,
+      })),
     });
 
     for (let i = 0; i < textTracks.length; i++) {
@@ -174,28 +178,20 @@ export function useVideoElement({
     }
 
     if (trackId && trackId !== 'off') {
-      const targetTrack = subtitleTracks.find((t) => t.id === trackId);
-      let found = false;
+      // Find which index in our subtitleTracks array matches the selected ID
+      const targetIndex = subtitleTracks.findIndex((t) => t.id === trackId);
 
-      for (let i = 0; i < textTracks.length; i++) {
-        const track = textTracks[i];
-        if (
-          track.id === trackId ||
-          (targetTrack && track.label === targetTrack.label) ||
-          (targetTrack && track.language === targetTrack.language)
-        ) {
-          track.mode = 'showing';
-          found = true;
-          break;
-        }
-      }
-
-      if (!found) {
+      if (targetIndex !== -1 && targetIndex < textTracks.length) {
+        // Direct index match — track elements render in the same order as subtitleTracks
+        textTracks[targetIndex].mode = 'showing';
+      } else {
+        // Fallback: match by id, label, or language on the TextTrack object
+        const targetTrack = subtitleTracks.find((t) => t.id === trackId);
         for (let i = 0; i < textTracks.length; i++) {
           const track = textTracks[i];
           if (
-            targetTrack &&
-            track.label.toLowerCase().includes(targetTrack.label.toLowerCase())
+            track.id === trackId ||
+            (targetTrack && track.label === targetTrack.label)
           ) {
             track.mode = 'showing';
             break;


### PR DESCRIPTION
## Changes

### Music & Manga
- Centered search bar in header with FLIP animation to spotlight overlay
- Removed biome-ignore, properly added originRect to deps

### Player - Subtitle Fix
- Index-based track switching (fixes only first subtitle working)
- Hide native cue boxes (fixes empty space below subtitles)

### Player - Debug Overlay
- Debug button on staging (replaces keyboard shortcut)
- Logs subtitle/audio track changes in overlay
- Added NW-prefixed console logs for diagnosis