### PR TITLE
feat: music player mobile UX, volume control, player fixes

### DIFF
--- a/src/features/manga/components/MangaClient.tsx
+++ b/src/features/manga/components/MangaClient.tsx
@@ -105,10 +105,6 @@ export function MangaClient() {
   const [titles, setTitles] = useState<MangaTitle[]>([]);
   const [loading, setLoading] = useState(true);
   const [showSearch, setShowSearch] = useState(false);
-  const [searchOriginRect, setSearchOriginRect] = useState<DOMRect | null>(
-    null,
-  );
-  const searchRef = useRef<HTMLButtonElement>(null);
   const t = useTranslations('common.manga');
 
   const fetchData = useCallback(async (t: Tab) => {
@@ -199,10 +195,7 @@ export function MangaClient() {
     <main className="pb-32 animate-in fade-in">
       {/* Search Spotlight */}
       {showSearch && (
-        <MangaSearchSpotlight
-          originRect={searchOriginRect}
-          onClose={() => setShowSearch(false)}
-        />
+        <MangaSearchSpotlight onClose={() => setShowSearch(false)} />
       )}
 
       {/* Header — like music */}
@@ -211,14 +204,9 @@ export function MangaClient() {
           {t('title')}
         </h1>
         <button
-          ref={searchRef}
           type="button"
-          onClick={() => {
-            const rect = searchRef.current?.getBoundingClientRect();
-            if (rect) setSearchOriginRect(rect);
-            setShowSearch(true);
-          }}
-          className="flex-1 max-w-md h-10 flex items-center gap-2 px-4 rounded-full bg-card border-[2px] border-border hover:border-neo-cyan hover:bg-neo-cyan/10 transition-colors cursor-pointer"
+          onClick={() => setShowSearch(true)}
+          className="flex-1 max-w-md min-w-0 h-10 flex items-center gap-2 px-4 rounded-full bg-card border-[2px] border-border hover:border-neo-cyan hover:bg-neo-cyan/10 transition-colors cursor-pointer"
           aria-label={t('searchAriaLabel')}
         >
           <Search className="w-4 h-4 text-foreground/40 shrink-0" />

--- a/src/features/manga/components/MangaSearchSpotlight.tsx
+++ b/src/features/manga/components/MangaSearchSpotlight.tsx
@@ -8,13 +8,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MangaTitle } from '@/features/manga/api';
 import { searchManga } from '@/features/manga/api';
 
-export function MangaSearchSpotlight({
-  originRect,
-  onClose,
-}: {
-  originRect?: DOMRect | null;
-  onClose: () => void;
-}) {
+export function MangaSearchSpotlight({ onClose }: { onClose: () => void }) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<MangaTitle[] | null>(null);
   const [loading, setLoading] = useState(false);
@@ -24,28 +18,17 @@ export function MangaSearchSpotlight({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const t = useTranslations('common.manga');
 
-  // FLIP animation + initial setup
+  // Smooth entrance animation
   useEffect(() => {
     requestAnimationFrame(() => setVisible(true));
 
-    // FLIP animation: animate input bar from header search bar position
-    if (originRect && searchBarRef.current) {
-      const el = searchBarRef.current;
-      const finalRect = el.getBoundingClientRect();
-      const dx = originRect.left - finalRect.left;
-      const dy = originRect.top - finalRect.top;
-      const sx = originRect.width / finalRect.width;
-      const sy = originRect.height / finalRect.height;
-
-      el.animate(
+    if (searchBarRef.current) {
+      searchBarRef.current.animate(
         [
-          {
-            transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`,
-            opacity: 0.8,
-          },
-          { transform: 'translate(0, 0) scale(1, 1)', opacity: 1 },
+          { transform: 'translateY(8px)', opacity: 0 },
+          { transform: 'translateY(0)', opacity: 1 },
         ],
-        { duration: 300, easing: 'cubic-bezier(0.4, 0, 0.2, 1)', fill: 'both' },
+        { duration: 250, easing: 'cubic-bezier(0.2, 0, 0, 1)', fill: 'both' },
       );
     }
 
@@ -55,7 +38,7 @@ export function MangaSearchSpotlight({
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [originRect]);
+  }, []);
 
   const close = () => {
     setVisible(false);
@@ -96,7 +79,7 @@ export function MangaSearchSpotlight({
       tabIndex={-1}
     >
       <div
-        className={`w-full max-w-xl mx-4 max-h-[80vh] flex flex-col overflow-hidden transition-all duration-200 ${visible ? 'scale-100 opacity-100' : originRect ? 'scale-100 opacity-0' : 'scale-75 opacity-0'}`}
+        className={`w-full max-w-xl mx-4 max-h-[80vh] flex flex-col overflow-hidden transition-all duration-200 ${visible ? 'scale-100 opacity-100' : 'scale-100 opacity-0'}`}
       >
         {/* Input */}
         <div

--- a/src/features/music/components/FullPlayer.tsx
+++ b/src/features/music/components/FullPlayer.tsx
@@ -12,6 +12,7 @@ import {
   useMusicPlaybackProgress,
   useMusicPlayerContext,
 } from '../context/MusicPlayerContext';
+import { useNativeVolume } from '../hooks/use-native-volume';
 import { DesktopFullPlayer } from './DesktopFullPlayer';
 import { MobileFullPlayer } from './MobileFullPlayer';
 
@@ -59,6 +60,7 @@ export function FullPlayer() {
   const { progress, duration } = useMusicPlaybackProgress();
 
   const mobile = useIsMobile();
+  const nativeVol = useNativeVolume(mobile && !!expanded);
   const [closing, setClosing] = useState(false);
   const [lyrics, setLyrics] = useState<SyncedLyricLine[] | null>(null);
   const [recommendations, setRecommendations] = useState<MusicTrack[]>([]);
@@ -237,7 +239,11 @@ export function FullPlayer() {
         )
     : seek;
   const handleSetVolume = (v: number) => {
-    setVolume(v);
+    if (nativeVol.isNative) {
+      nativeVol.setVolume(v);
+    } else {
+      setVolume(v);
+    }
     if (isRemoteControlling) {
       window.dispatchEvent(
         new CustomEvent('music:remote-command', {
@@ -254,7 +260,7 @@ export function FullPlayer() {
         isPlaying={displayPlaying}
         progress={displayProgress}
         duration={displayDuration}
-        volume={volume}
+        volume={nativeVol.isNative ? nativeVol.volume : volume}
         queue={isRemoteControlling ? remoteQueue : queue}
         lyrics={lyrics}
         currentLineIndex={currentLineIndex}

--- a/src/features/music/components/MiniPlayer.tsx
+++ b/src/features/music/components/MiniPlayer.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {
-  ListMusic,
   Pause,
   Play,
   SkipBack,
@@ -19,7 +18,6 @@ import {
 } from '../context/MusicPlayerContext';
 import { useMusicShortcuts } from '../hooks/use-music-shortcuts';
 import { MusicDevicePicker } from './MusicDevicePicker';
-import { QueueOverlay } from './QueueOverlay';
 import { showSongMenu } from './SongContextMenu';
 
 /**
@@ -48,7 +46,6 @@ export function MiniPlayer() {
   const {
     currentTrack,
     isPlaying,
-    queue,
     togglePlay,
     next,
     prev,
@@ -62,7 +59,6 @@ export function MiniPlayer() {
     remoteIsPlaying,
     remoteProgress,
     remoteDuration,
-    remoteQueue,
   } = player;
 
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -104,12 +100,9 @@ export function MiniPlayer() {
       longPressTimer.current = null;
     }
   };
-  const [showQueue, setShowQueue] = useState(false);
-
   // Show MiniPlayer if local track OR remote controlling
   const displayTrack = isRemoteControlling ? remoteTrack : currentTrack;
   const displayPlaying = isRemoteControlling ? remoteIsPlaying : isPlaying;
-  const displayQueue = isRemoteControlling ? remoteQueue : queue;
 
   // Interpolate remote progress locally for smooth bar animation
   const [interpolatedSeconds, setInterpolatedSeconds] = useState(0);
@@ -331,24 +324,8 @@ export function MiniPlayer() {
             </>
           )}
           <MusicDevicePicker />
-          <button
-            type="button"
-            onClick={() => setShowQueue((v) => !v)}
-            className={`p-1.5 transition-colors ${showQueue ? 'text-neo-yellow' : 'text-foreground/20 hover:text-foreground'}`}
-            title={t('queueTitle')}
-          >
-            <ListMusic className="w-3.5 h-3.5" />
-          </button>
         </div>
       </div>
-
-      <QueueOverlay
-        open={showQueue}
-        onClose={() => setShowQueue(false)}
-        displayQueue={displayQueue}
-        displayTrackId={displayTrack?.id}
-        isRemoteControlling={isRemoteControlling}
-      />
     </div>
   );
 }

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -184,7 +184,10 @@ export function MobileFullPlayer({
           /* ===== MAIN VIEW ===== */
           <div className="flex-1 flex flex-col min-h-0">
             {/* Album art / lyrics area */}
-            <div className="shrink-0 flex flex-col" style={{ height: '40vh' }}>
+            <div
+              className="shrink-0 flex flex-col mt-6"
+              style={{ height: '40vh' }}
+            >
               {showLyrics && hasLyrics ? (
                 <>
                   <div className="shrink-0 flex items-center gap-3 py-2 animate-in fade-in duration-300">
@@ -225,7 +228,7 @@ export function MobileFullPlayer({
                 </div>
               )}
             </div>
-            <div className="shrink-0 w-full mt-3 mb-2">
+            <div className="shrink-0 w-full mt-6 mb-2">
               <h2 className="text-white font-bold text-xl truncate">
                 {currentTrack.title}
               </h2>
@@ -233,7 +236,7 @@ export function MobileFullPlayer({
                 {currentTrack.artist}
               </p>
             </div>
-            <div className="shrink-0 w-full mt-6">
+            <div className="shrink-0 w-full mt-8">
               <div
                 ref={seekBarRef}
                 className="w-full py-3 cursor-pointer relative"
@@ -292,7 +295,7 @@ export function MobileFullPlayer({
                 </span>
               </div>
             </div>
-            <div className="shrink-0 flex items-center justify-center gap-12 mt-9">
+            <div className="shrink-0 flex items-center justify-center gap-12 mt-14">
               <button type="button" onClick={onPrev} className="text-white">
                 <SkipBack className="w-9 h-9 fill-current" />
               </button>
@@ -311,7 +314,7 @@ export function MobileFullPlayer({
                 <SkipForward className="w-9 h-9 fill-current" />
               </button>
             </div>
-            <div className="shrink-0 flex items-center gap-3 mt-5">
+            <div className="shrink-0 flex items-center gap-3 mt-[5.2rem]">
               <Volume1 className="w-3.5 h-3.5 text-white/30" />
               <input
                 type="range"
@@ -329,7 +332,7 @@ export function MobileFullPlayer({
             </div>
 
             {/* Bottom bar: lyrics / eq / sleep / queue */}
-            <div className="flex items-center justify-around mt-auto py-2">
+            <div className="flex items-center justify-around mt-8 py-2">
               <button
                 type="button"
                 onClick={onToggleLyrics}

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -154,10 +154,14 @@ export function MobileFullPlayer({
                   key={track.id}
                   type="button"
                   onClick={() => onPlay(track, queue)}
-                  className={`w-full flex items-center gap-3 py-2 text-left ${currentTrack?.id === track.id ? 'text-white' : 'text-white/60'}`}
+                  className={`w-full flex items-center gap-3 py-2 text-left ${currentTrack?.id === track.id ? 'text-white bg-white/5 rounded-lg px-1' : 'text-white/60'}`}
                 >
-                  <span className="w-5 text-white/20 text-[10px] font-mono text-right shrink-0">
-                    {i + 1}
+                  <span className="w-5 text-[10px] font-mono text-right shrink-0">
+                    {currentTrack?.id === track.id ? (
+                      <span className="text-neo-yellow">▶</span>
+                    ) : (
+                      <span className="text-white/20">{i + 1}</span>
+                    )}
                   </span>
                   <img
                     src={track.image}

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -292,7 +292,7 @@ export function MobileFullPlayer({
                 </span>
               </div>
             </div>
-            <div className="shrink-0 flex items-center justify-center gap-12 mt-5">
+            <div className="shrink-0 flex items-center justify-center gap-12 mt-7">
               <button type="button" onClick={onPrev} className="text-white">
                 <SkipBack className="w-9 h-9 fill-current" />
               </button>

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -225,7 +225,7 @@ export function MobileFullPlayer({
                 </div>
               )}
             </div>
-            <div className="shrink-0 w-full mb-2">
+            <div className="shrink-0 w-full mt-auto mb-2">
               <h2 className="text-white font-bold text-xl truncate">
                 {currentTrack.title}
               </h2>
@@ -329,7 +329,7 @@ export function MobileFullPlayer({
             </div>
 
             {/* Bottom bar: lyrics / eq / sleep / queue */}
-            <div className="flex items-center justify-around mt-6 py-2">
+            <div className="flex items-center justify-around mt-auto py-2">
               <button
                 type="button"
                 onClick={onToggleLyrics}

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -72,6 +72,15 @@ export function MobileFullPlayer({
   const [swipeOffset, setSwipeOffset] = useState(0);
   const [showEq, setShowEq] = useState(false);
   const [showSleep, setShowSleep] = useState(false);
+  const [closingQueue, setClosingQueue] = useState(false);
+
+  const handleCloseQueue = () => {
+    setClosingQueue(true);
+    setTimeout(() => {
+      setClosingQueue(false);
+      onToggleQueue();
+    }, 250);
+  };
 
   // Seek bar state
   const seekBarRef = useRef<HTMLDivElement>(null);
@@ -135,14 +144,16 @@ export function MobileFullPlayer({
 
         {showQueue ? (
           /* ===== QUEUE MODE ===== */
-          <div className="flex-1 min-h-0 flex flex-col">
+          <div
+            className={`flex-1 min-h-0 flex flex-col transition-all duration-250 ${closingQueue ? 'opacity-0 translate-y-4' : 'opacity-100 translate-y-0 animate-in fade-in slide-in-from-bottom-4 duration-300'}`}
+          >
             <div className="shrink-0 flex items-center justify-between pb-2">
               <p className="text-white/30 font-headline font-bold uppercase tracking-widest text-[10px]">
                 {t('queue', { count: queue.length })}
               </p>
               <button
                 type="button"
-                onClick={onToggleQueue}
+                onClick={handleCloseQueue}
                 className="text-white/50 text-xs font-bold uppercase tracking-wider"
               >
                 {t('close')}

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -225,7 +225,7 @@ export function MobileFullPlayer({
                 </div>
               )}
             </div>
-            <div className="shrink-0 w-full mt-auto mb-2">
+            <div className="shrink-0 w-full mt-3 mb-2">
               <h2 className="text-white font-bold text-xl truncate">
                 {currentTrack.title}
               </h2>
@@ -233,7 +233,7 @@ export function MobileFullPlayer({
                 {currentTrack.artist}
               </p>
             </div>
-            <div className="shrink-0 w-full mt-4">
+            <div className="shrink-0 w-full mt-6">
               <div
                 ref={seekBarRef}
                 className="w-full py-3 cursor-pointer relative"

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -327,14 +327,9 @@ export function MobileFullPlayer({
               />
               <Volume2 className="w-3.5 h-3.5 text-white/30" />
             </div>
-          </div>
-        )}
 
-        {/* ===== BOTTOM BAR ===== */}
-        {!showQueue && (
-          <div className="shrink-0 pb-1">
-            {/* Bottom bar: lyrics / eq / airplay / sleep / queue */}
-            <div className="flex items-center justify-around pb-1">
+            {/* Bottom bar: lyrics / eq / sleep / queue */}
+            <div className="mt-auto flex items-center justify-around py-2">
               <button
                 type="button"
                 onClick={onToggleLyrics}

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -329,7 +329,7 @@ export function MobileFullPlayer({
             </div>
 
             {/* Bottom bar: lyrics / eq / sleep / queue */}
-            <div className="mt-auto flex items-center justify-around py-2">
+            <div className="flex items-center justify-around mt-6 py-2">
               <button
                 type="button"
                 onClick={onToggleLyrics}

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -184,7 +184,7 @@ export function MobileFullPlayer({
           /* ===== MAIN VIEW ===== */
           <div className="flex-1 flex flex-col min-h-0">
             {/* Fixed-height content area — same size for art and lyrics */}
-            <div className="shrink-0 flex flex-col" style={{ height: '50vh' }}>
+            <div className="shrink-0 flex flex-col" style={{ height: '45vh' }}>
               {showLyrics && hasLyrics ? (
                 <>
                   <div className="shrink-0 flex items-center gap-3 py-2 animate-in fade-in duration-300">
@@ -215,7 +215,7 @@ export function MobileFullPlayer({
                 </>
               ) : (
                 <div className="flex-1 flex items-center justify-center">
-                  <div className="w-full aspect-square max-h-[45vh]">
+                  <div className="w-full aspect-square max-h-[38vh]">
                     <img
                       src={currentTrack.image}
                       alt={currentTrack.title}
@@ -225,7 +225,7 @@ export function MobileFullPlayer({
                 </div>
               )}
             </div>
-            <div className="shrink-0 w-full mb-6">
+            <div className="shrink-0 w-full mb-4">
               <h2 className="text-white font-bold text-xl truncate">
                 {currentTrack.title}
               </h2>
@@ -233,7 +233,7 @@ export function MobileFullPlayer({
                 {currentTrack.artist}
               </p>
             </div>
-            <div className="shrink-0 w-full mt-4">
+            <div className="shrink-0 w-full mt-2">
               <div
                 ref={seekBarRef}
                 className="w-full py-3 cursor-pointer relative"
@@ -292,7 +292,7 @@ export function MobileFullPlayer({
                 </span>
               </div>
             </div>
-            <div className="shrink-0 flex items-center justify-center gap-12 mt-5">
+            <div className="shrink-0 flex items-center justify-center gap-12 mt-3">
               <button type="button" onClick={onPrev} className="text-white">
                 <SkipBack className="w-9 h-9 fill-current" />
               </button>

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -128,7 +128,7 @@ export function MobileFullPlayer({
         <button
           type="button"
           onClick={onClose}
-          className="shrink-0 flex justify-center pt-3 pb-6"
+          className="shrink-0 flex justify-center pt-3 pb-4"
         >
           <div className="w-10 h-1 rounded-full bg-white/30" />
         </button>
@@ -183,8 +183,8 @@ export function MobileFullPlayer({
         ) : (
           /* ===== MAIN VIEW ===== */
           <div className="flex-1 flex flex-col min-h-0">
-            {/* Fixed-height content area — same size for art and lyrics */}
-            <div className="shrink-0 flex flex-col" style={{ height: '45vh' }}>
+            {/* Album art / lyrics area */}
+            <div className="shrink-0 flex flex-col" style={{ height: '42vh' }}>
               {showLyrics && hasLyrics ? (
                 <>
                   <div className="shrink-0 flex items-center gap-3 py-2 animate-in fade-in duration-300">
@@ -225,7 +225,7 @@ export function MobileFullPlayer({
                 </div>
               )}
             </div>
-            <div className="shrink-0 w-full mb-4">
+            <div className="shrink-0 w-full mb-2">
               <h2 className="text-white font-bold text-xl truncate">
                 {currentTrack.title}
               </h2>
@@ -233,7 +233,7 @@ export function MobileFullPlayer({
                 {currentTrack.artist}
               </p>
             </div>
-            <div className="shrink-0 w-full mt-2">
+            <div className="shrink-0 w-full">
               <div
                 ref={seekBarRef}
                 className="w-full py-3 cursor-pointer relative"
@@ -311,7 +311,7 @@ export function MobileFullPlayer({
                 <SkipForward className="w-9 h-9 fill-current" />
               </button>
             </div>
-            <div className="shrink-0 flex items-center gap-3 mt-5">
+            <div className="shrink-0 flex items-center gap-3 mt-3">
               <Volume1 className="w-3.5 h-3.5 text-white/30" />
               <input
                 type="range"

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -184,7 +184,7 @@ export function MobileFullPlayer({
           /* ===== MAIN VIEW ===== */
           <div className="flex-1 flex flex-col min-h-0">
             {/* Album art / lyrics area */}
-            <div className="shrink-0 flex flex-col" style={{ height: '42vh' }}>
+            <div className="shrink-0 flex flex-col" style={{ height: '40vh' }}>
               {showLyrics && hasLyrics ? (
                 <>
                   <div className="shrink-0 flex items-center gap-3 py-2 animate-in fade-in duration-300">
@@ -292,7 +292,7 @@ export function MobileFullPlayer({
                 </span>
               </div>
             </div>
-            <div className="shrink-0 flex items-center justify-center gap-12 mt-7">
+            <div className="shrink-0 flex items-center justify-center gap-12 mt-9">
               <button type="button" onClick={onPrev} className="text-white">
                 <SkipBack className="w-9 h-9 fill-current" />
               </button>

--- a/src/features/music/components/MobileFullPlayer.tsx
+++ b/src/features/music/components/MobileFullPlayer.tsx
@@ -233,7 +233,7 @@ export function MobileFullPlayer({
                 {currentTrack.artist}
               </p>
             </div>
-            <div className="shrink-0 w-full">
+            <div className="shrink-0 w-full mt-4">
               <div
                 ref={seekBarRef}
                 className="w-full py-3 cursor-pointer relative"
@@ -292,7 +292,7 @@ export function MobileFullPlayer({
                 </span>
               </div>
             </div>
-            <div className="shrink-0 flex items-center justify-center gap-12 mt-3">
+            <div className="shrink-0 flex items-center justify-center gap-12 mt-5">
               <button type="button" onClick={onPrev} className="text-white">
                 <SkipBack className="w-9 h-9 fill-current" />
               </button>
@@ -311,7 +311,7 @@ export function MobileFullPlayer({
                 <SkipForward className="w-9 h-9 fill-current" />
               </button>
             </div>
-            <div className="shrink-0 flex items-center gap-3 mt-3">
+            <div className="shrink-0 flex items-center gap-3 mt-5">
               <Volume1 className="w-3.5 h-3.5 text-white/30" />
               <input
                 type="range"

--- a/src/features/music/components/MusicHeader.tsx
+++ b/src/features/music/components/MusicHeader.tsx
@@ -2,7 +2,6 @@
 
 import { Globe, Plus, Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useRef } from 'react';
 
 /**
  * Props for the {@link MusicHeader} component.
@@ -14,8 +13,8 @@ interface MusicHeaderProps {
   onOpenLangPicker: () => void;
   /** Toggles the {@link CreatePlaylistDialog}. */
   onToggleCreatePlaylist: () => void;
-  /** Opens the {@link MusicSearchSpotlight} overlay, passing the origin rect for animation. */
-  onOpenSearch: (originRect: DOMRect) => void;
+  /** Opens the {@link MusicSearchSpotlight} overlay. */
+  onOpenSearch: () => void;
 }
 
 /**
@@ -37,7 +36,6 @@ export function MusicHeader({
   onOpenSearch,
 }: MusicHeaderProps) {
   const t = useTranslations('music');
-  const searchRef = useRef<HTMLButtonElement>(null);
 
   return (
     <div className="flex items-center justify-between px-6 pt-6 pb-2 gap-3">
@@ -45,12 +43,8 @@ export function MusicHeader({
         {t('title')}
       </h1>
       <button
-        ref={searchRef}
         type="button"
-        onClick={() => {
-          const rect = searchRef.current?.getBoundingClientRect();
-          if (rect) onOpenSearch(rect);
-        }}
+        onClick={onOpenSearch}
         className="flex-1 max-w-md min-w-0 h-10 flex items-center gap-2 px-4 rounded-full bg-card border-[2px] border-border hover:border-neo-yellow hover:bg-neo-yellow/10 transition-colors cursor-pointer"
         aria-label={t('searchMusic')}
       >

--- a/src/features/music/components/MusicHeader.tsx
+++ b/src/features/music/components/MusicHeader.tsx
@@ -51,7 +51,7 @@ export function MusicHeader({
           const rect = searchRef.current?.getBoundingClientRect();
           if (rect) onOpenSearch(rect);
         }}
-        className="flex-1 max-w-md h-10 flex items-center gap-2 px-4 rounded-full bg-card border-[2px] border-border hover:border-neo-yellow hover:bg-neo-yellow/10 transition-colors cursor-pointer"
+        className="flex-1 max-w-md min-w-0 h-10 flex items-center gap-2 px-4 rounded-full bg-card border-[2px] border-border hover:border-neo-yellow hover:bg-neo-yellow/10 transition-colors cursor-pointer"
         aria-label={t('searchMusic')}
       >
         <Search className="w-4 h-4 text-foreground/40 shrink-0" />

--- a/src/features/music/components/MusicSearchSpotlight.tsx
+++ b/src/features/music/components/MusicSearchSpotlight.tsx
@@ -36,13 +36,7 @@ import { showSongMenu } from './SongContextMenu';
  *
  * @param props.onClose - Callback invoked after the closing animation completes.
  */
-export function MusicSearchSpotlight({
-  originRect,
-  onClose,
-}: {
-  originRect?: DOMRect | null;
-  onClose: () => void;
-}) {
+export function MusicSearchSpotlight({ onClose }: { onClose: () => void }) {
   const t = useTranslations('music');
   const player = useMusicPlayerContext();
   const [query, setQuery] = useState('');
@@ -87,28 +81,17 @@ export function MusicSearchSpotlight({
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressTriggered = useRef(false);
 
-  // FLIP animation + initial setup
+  // Smooth entrance animation
   useEffect(() => {
     requestAnimationFrame(() => setVisible(true));
 
-    // FLIP animation: animate input bar from header search bar position
-    if (originRect && searchBarRef.current) {
-      const el = searchBarRef.current;
-      const finalRect = el.getBoundingClientRect();
-      const dx = originRect.left - finalRect.left;
-      const dy = originRect.top - finalRect.top;
-      const sx = originRect.width / finalRect.width;
-      const sy = originRect.height / finalRect.height;
-
-      el.animate(
+    if (searchBarRef.current) {
+      searchBarRef.current.animate(
         [
-          {
-            transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`,
-            opacity: 0.8,
-          },
-          { transform: 'translate(0, 0) scale(1, 1)', opacity: 1 },
+          { transform: 'translateY(8px)', opacity: 0 },
+          { transform: 'translateY(0)', opacity: 1 },
         ],
-        { duration: 300, easing: 'cubic-bezier(0.4, 0, 0.2, 1)', fill: 'both' },
+        { duration: 250, easing: 'cubic-bezier(0.2, 0, 0, 1)', fill: 'both' },
       );
     }
 
@@ -124,7 +107,7 @@ export function MusicSearchSpotlight({
         clearTimeout(debounceRef.current);
       }
     };
-  }, [originRect]);
+  }, []);
 
   const close = () => {
     setVisible(false);
@@ -222,7 +205,7 @@ export function MusicSearchSpotlight({
       tabIndex={-1}
     >
       <div
-        className={`w-full max-w-xl mx-4 max-h-[80vh] flex flex-col overflow-hidden transition-all duration-200 ${visible ? 'scale-100 opacity-100' : originRect ? 'scale-100 opacity-0' : 'scale-75 opacity-0'}`}
+        className={`w-full max-w-xl mx-4 max-h-[80vh] flex flex-col overflow-hidden transition-all duration-200 ${visible ? 'scale-100 opacity-100' : 'scale-100 opacity-0'}`}
       >
         {/* Input */}
         <div

--- a/src/features/music/components/MusicView.tsx
+++ b/src/features/music/components/MusicView.tsx
@@ -47,9 +47,6 @@ export function MusicView() {
     podcasts: [],
   });
   const [showSearch, setShowSearch] = useState(false);
-  const [searchOriginRect, setSearchOriginRect] = useState<DOMRect | null>(
-    null,
-  );
   const [showCreatePlaylist, setShowCreatePlaylist] = useState(false);
   const [loading, setLoading] = useState(true);
   const [playlistKey, setPlaylistKey] = useState(0);
@@ -112,10 +109,7 @@ export function MusicView() {
         selectedLangs={selectedLangs}
         onOpenLangPicker={() => setShowLangPicker(true)}
         onToggleCreatePlaylist={() => setShowCreatePlaylist((v) => !v)}
-        onOpenSearch={(rect) => {
-          setSearchOriginRect(rect);
-          setShowSearch(true);
-        }}
+        onOpenSearch={() => setShowSearch(true)}
       />
 
       {showCreatePlaylist && (
@@ -145,10 +139,7 @@ export function MusicView() {
       )}
 
       {showSearch && (
-        <MusicSearchSpotlight
-          originRect={searchOriginRect}
-          onClose={() => setShowSearch(false)}
-        />
+        <MusicSearchSpotlight onClose={() => setShowSearch(false)} />
       )}
     </div>
   );

--- a/src/features/music/components/MusicView.tsx
+++ b/src/features/music/components/MusicView.tsx
@@ -107,7 +107,7 @@ export function MusicView() {
   }, [searchParams, player]);
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 overflow-y-auto pb-28">
+    <div className="flex-1 flex flex-col min-h-0 overflow-y-auto overflow-x-hidden pb-28">
       <MusicHeader
         selectedLangs={selectedLangs}
         onOpenLangPicker={() => setShowLangPicker(true)}

--- a/src/features/music/hooks/use-native-volume.ts
+++ b/src/features/music/hooks/use-native-volume.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
  * Hook that bridges to native system volume on Capacitor (iOS/Android).
- * Falls back to no-op on web. Returns [volume (0-1), setVolume].
- * Also polls for hardware button changes to keep the slider in sync.
+ * Falls back to no-op on web. Returns volume (0-1) and setVolume.
+ * Listens to hardware volume button presses for instant slider sync.
  */
 export function useNativeVolume(enabled: boolean) {
   const [volume, setVolumeState] = useState(0.5);
-  const pollRef = useRef<ReturnType<typeof setInterval>>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
 
   const isNative =
     typeof window !== 'undefined' && !!window.Capacitor?.isNativePlatform?.();
@@ -30,7 +30,7 @@ export function useNativeVolume(enabled: boolean) {
       } else {
         const { Volumes } = await import('@ottimis/capacitor-volumes');
         const { value } = await Volumes.getVolumeLevel({ type: 3 });
-        setVolumeState(value / 10); // Android returns 0-10, normalize to 0-1
+        setVolumeState(value / 10);
       }
     } catch {}
   }, [isNative, isIos]);
@@ -57,13 +57,31 @@ export function useNativeVolume(enabled: boolean) {
     [isNative, isIos],
   );
 
-  // Poll for hardware button changes
+  // Listen for hardware volume button presses → instant sync
   useEffect(() => {
     if (!enabled || !isNative) return;
     getVolume();
-    pollRef.current = setInterval(getVolume, 1000);
+
+    let active = true;
+    (async () => {
+      try {
+        const { VolumeButtons } = await import(
+          '@capacitor-community/volume-buttons'
+        );
+        await VolumeButtons.watchVolume({}, () => {
+          // Button pressed — immediately read the new system volume
+          if (active) getVolume();
+        });
+        cleanupRef.current = () => {
+          VolumeButtons.clearWatch().catch(() => {});
+        };
+      } catch {}
+    })();
+
     return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
+      active = false;
+      cleanupRef.current?.();
+      cleanupRef.current = null;
     };
   }, [enabled, isNative, getVolume]);
 

--- a/src/features/music/hooks/use-native-volume.ts
+++ b/src/features/music/hooks/use-native-volume.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Hook that bridges to native system volume on Capacitor (iOS/Android).
+ * Falls back to no-op on web. Returns [volume (0-1), setVolume].
+ * Also polls for hardware button changes to keep the slider in sync.
+ */
+export function useNativeVolume(enabled: boolean) {
+  const [volume, setVolumeState] = useState(0.5);
+  const pollRef = useRef<ReturnType<typeof setInterval>>(null);
+
+  const isNative =
+    typeof window !== 'undefined' && !!window.Capacitor?.isNativePlatform?.();
+  const isIos =
+    typeof window !== 'undefined' &&
+    window.Capacitor?.getPlatform?.() === 'ios';
+
+  // Get current volume from native
+  const getVolume = useCallback(async () => {
+    if (!isNative) return;
+    try {
+      if (isIos) {
+        const { registerPlugin } = await import('@capacitor/core');
+        const NWVolume = registerPlugin<{
+          getVolume: () => Promise<{ value: number }>;
+          setVolume: (opts: { value: number }) => Promise<{ value: number }>;
+        }>('NWVolume');
+        const { value } = await NWVolume.getVolume();
+        setVolumeState(value);
+      } else {
+        const { Volumes } = await import('@ottimis/capacitor-volumes');
+        const { value } = await Volumes.getVolumeLevel({ type: 3 });
+        setVolumeState(value / 10); // Android returns 0-10, normalize to 0-1
+      }
+    } catch {}
+  }, [isNative, isIos]);
+
+  // Set system volume
+  const setVolume = useCallback(
+    async (v: number) => {
+      setVolumeState(v);
+      if (!isNative) return;
+      try {
+        if (isIos) {
+          const { registerPlugin } = await import('@capacitor/core');
+          const NWVolume = registerPlugin<{
+            getVolume: () => Promise<{ value: number }>;
+            setVolume: (opts: { value: number }) => Promise<{ value: number }>;
+          }>('NWVolume');
+          await NWVolume.setVolume({ value: v });
+        } else {
+          const { Volumes } = await import('@ottimis/capacitor-volumes');
+          await Volumes.setVolumeLevel({ value: Math.round(v * 10), type: 3 });
+        }
+      } catch {}
+    },
+    [isNative, isIos],
+  );
+
+  // Poll for hardware button changes
+  useEffect(() => {
+    if (!enabled || !isNative) return;
+    getVolume();
+    pollRef.current = setInterval(getVolume, 1000);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [enabled, isNative, getVolume]);
+
+  return { volume, setVolume, isNative };
+}

--- a/src/features/music/hooks/use-native-volume.ts
+++ b/src/features/music/hooks/use-native-volume.ts
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 export function useNativeVolume(enabled: boolean) {
   const [volume, setVolumeState] = useState(0.5);
   const cleanupRef = useRef<(() => void) | null>(null);
+  const userSetRef = useRef(0); // timestamp of last manual set (to suppress feedback)
 
   const isNative =
     typeof window !== 'undefined' && !!window.Capacitor?.isNativePlatform?.();
@@ -38,6 +39,7 @@ export function useNativeVolume(enabled: boolean) {
   // Set system volume
   const setVolume = useCallback(
     async (v: number) => {
+      userSetRef.current = Date.now();
       setVolumeState(v);
       if (!isNative) return;
       try {
@@ -70,7 +72,8 @@ export function useNativeVolume(enabled: boolean) {
         );
         await VolumeButtons.watchVolume({}, () => {
           // Button pressed — immediately read the new system volume
-          if (active) getVolume();
+          // Skip if user just set volume from slider (prevents feedback loop)
+          if (active && Date.now() - userSetRef.current > 500) getVolume();
         });
         cleanupRef.current = () => {
           VolumeButtons.clearWatch().catch(() => {});

--- a/src/features/watch/player/ui/overlays/DebugOverlay.tsx
+++ b/src/features/watch/player/ui/overlays/DebugOverlay.tsx
@@ -78,6 +78,13 @@ export function DebugOverlay() {
       addLog(`🔊 Audio → ${state.currentAudioTrack}`);
   }, [state.currentAudioTrack, addLog]);
 
+  useEffect(() => {
+    if (!isStaging || state.audioTracks.length === 0) return;
+    addLog(
+      `🎧 Audio tracks: ${state.audioTracks.map((t) => t.label).join(', ')}`,
+    );
+  }, [state.audioTracks, addLog]);
+
   // Log stream URL changes (refetch detection)
   useEffect(() => {
     if (!visible || !isStaging) return;

--- a/src/i18n/messages/ar/music.json
+++ b/src/i18n/messages/ar/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/de/music.json
+++ b/src/i18n/messages/de/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/en/music.json
+++ b/src/i18n/messages/en/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/es/music.json
+++ b/src/i18n/messages/es/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/fr/music.json
+++ b/src/i18n/messages/fr/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/hi/music.json
+++ b/src/i18n/messages/hi/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/it/music.json
+++ b/src/i18n/messages/it/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/ja/music.json
+++ b/src/i18n/messages/ja/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/ko/music.json
+++ b/src/i18n/messages/ko/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/pt/music.json
+++ b/src/i18n/messages/pt/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/ru/music.json
+++ b/src/i18n/messages/ru/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/th/music.json
+++ b/src/i18n/messages/th/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/tr/music.json
+++ b/src/i18n/messages/tr/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/i18n/messages/zh/music.json
+++ b/src/i18n/messages/zh/music.json
@@ -98,5 +98,6 @@
     "failedToLoad": "Failed to load station"
   },
   "similarSongs": "Similar Songs",
-  "queue": "Queue — {count}"
+  "queue": "Queue — {count}",
+  "close": "Close"
 }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -75,6 +75,11 @@ export function getTokenExpiresAt(): number | null {
  * If the token has expired while JS timers were frozen, refresh immediately.
  */
 export async function revalidateTokenOnResume(): Promise<boolean> {
+  // Don't attempt refresh while offline — it will fail and the session
+  // may still be valid once connectivity returns.
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return true;
+  }
   if (!tokenExpiresAt) return true;
   if (Date.now() < tokenExpiresAt - 60000) {
     // Token still valid with >1 min margin — just reschedule the timer
@@ -245,7 +250,13 @@ export async function apiFetch<T>(
       // Refresh failed — only logout if session is truly invalid
       // (tokenExpiresAt cleared by 401/403 from refresh endpoint).
       // Transient errors (5xx, network) keep tokenExpiresAt set.
-      if (!tokenExpiresAt && typeof window !== 'undefined') {
+      // Also skip logout if the device is offline — the session may still be
+      // valid once connectivity returns.
+      if (
+        !tokenExpiresAt &&
+        typeof window !== 'undefined' &&
+        navigator.onLine !== false
+      ) {
         window.dispatchEvent(new CustomEvent('auth:expired'));
       }
 

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -50,8 +50,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const onVisible = () => {
       if (document.visibilityState === 'visible') revalidateTokenOnResume();
     };
+    const onOnline = () => revalidateTokenOnResume();
     document.addEventListener('visibilitychange', onVisible);
-    return () => document.removeEventListener('visibilitychange', onVisible);
+    window.addEventListener('online', onOnline);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('online', onOnline);
+    };
   }, []);
 
   const handleForceLogout = useCallback(


### PR DESCRIPTION
## Changes

### Music - Mobile Fullscreen Player
- Native system volume control (iOS: MPVolumeView, Android: capacitor-volumes)
- Instant volume sync on hardware button press via volume-buttons listener
- Fixed spacing: poster, title, seekbar, controls properly distributed
- Queue close animation (fade-out + slide-down)
- Removed queue button from mini player
- Fixed queue close button translation (missing i18n key)
- Highlight currently playing track in queue with ▶ indicator

### Music - Search
- Fixed horizontal page scroll on mobile (overflow-x-hidden)
- Replaced FLIP animation with smooth slide-up transition

### Player - Subtitles
- Index-based subtitle track switching (fixes only first subtitle working)
- Hidden native cue boxes (fixes empty space below subtitles)

### Player - Audio Language
- Fixed language dub switch for series (fetch as movie type for s1: IDs)
- Debug overlay: log audio track labels, subtitle changes

### Player - Debug
- Debug button on staging (replaces keyboard shortcut)
- Cmd/Ctrl+Shift+D removed (conflicted with Chrome DevTools)

### Auth
- Prevent logout when device is offline
- Retry token refresh on connectivity restore

### Backend (nightwatch-backend)
- Filter subtitle entries from audio track list (upstream returns subs in dubs array)