### PR TITLE
fix: TV APK build - skip google-services

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -55,7 +55,7 @@ apply from: 'capacitor.build.gradle'
 
 try {
     def servicesJSON = file('google-services.json')
-    if (servicesJSON.text) {
+    if (servicesJSON.text && !project.hasProperty('tvBuild')) {
         apply plugin: 'com.google.gms.google-services'
     }
 } catch(Exception e) {


### PR DESCRIPTION
TV build uses com.nightwatch.in.tv which isn't in google-services.json. Skip FCM for TV.