### PR TITLE
fix(ci): webOS build rimraf error

### DIFF
--- a/.github/workflows/build-webos.yml
+++ b/.github/workflows/build-webos.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Package webOS IPK
         run: |
           cd webos
-          ares-package .
-          ls -la *.ipk
+          ares-package . || true
+          ls *.ipk && echo "Package created successfully"
 
       - name: Upload IPK to Release
         if: github.event_name == 'release'


### PR DESCRIPTION
ares-package v3.2.4 has a bug where rimraf fails during cleanup but the IPK is already created. Use `|| true` to ignore the exit code and verify IPK exists.