### PR TITLE
fix(ci): tizen build XML version parse error

### DIFF
--- a/.github/workflows/build-tizen.yml
+++ b/.github/workflows/build-tizen.yml
@@ -50,7 +50,12 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           cd tizen
-          sed -i "s/version=\"[^\"]*\"/version=\"$VERSION\"/" config.xml
+          node -e "
+            const fs = require('fs');
+            let xml = fs.readFileSync('config.xml', 'utf8');
+            xml = xml.replace(/(widget[^>]*version=\")[^\"]*\"/, '\$1$VERSION\"');
+            fs.writeFileSync('config.xml', xml);
+          "
           echo "Building Tizen app v$VERSION"
 
       - name: Build and package WGT


### PR DESCRIPTION
The sed command was replacing `<?xml version="1.0">` with the app version, breaking XML parsing. Now uses node regex targeting only the widget element's version attribute.